### PR TITLE
fix: typo in workspace slug in api references

### DIFF
--- a/api-reference/issue-types/options/add-dropdown-options.mdx
+++ b/api-reference/issue-types/options/add-dropdown-options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Add dropdown options
 description: Allows you to define a list of options for the dropdown property type.
-api: POST /api/v1/workspaces/{workspace-slug}/projects/{project_id}/issue-properties/{property_id}/options/
+api: POST /api/v1/workspaces/{workspace_slug}/projects/{project_id}/issue-properties/{property_id}/options/
 ---
 
 ### Path parameters

--- a/api-reference/issue-types/options/delete-dropdown-options.mdx
+++ b/api-reference/issue-types/options/delete-dropdown-options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Delete property options
 description: Enables you to remove specific options from a dropdown custom property.
-api: DELETE /api/v1/workspaces/{workspace-slug}/projects/{project_id}/issue-properties/{property_id}/options/{option_id}/
+api: DELETE /api/v1/workspaces/{workspace_slug}/projects/{project_id}/issue-properties/{property_id}/options/{option_id}/
 ---
 
 ### Path parameters

--- a/api-reference/issue-types/options/get-option-details.mdx
+++ b/api-reference/issue-types/options/get-option-details.mdx
@@ -1,7 +1,7 @@
 ---
 title: Get option details
 description:  Retrieves information about a specific option within a dropdown property.
-api: GET /api/v1/workspaces/{workspace-slug}/projects/{project_id}/issue-properties/{property_id}/options/{option_id}/
+api: GET /api/v1/workspaces/{workspace_slug}/projects/{project_id}/issue-properties/{property_id}/options/{option_id}/
 ---
 
 ### Path parameters

--- a/api-reference/issue-types/options/list-dropdown-options.mdx
+++ b/api-reference/issue-types/options/list-dropdown-options.mdx
@@ -1,7 +1,7 @@
 ---
 title: List property options
 description: Retrieves all available options for a specific dropdown custom property. 
-api: GET /api/v1/workspaces/{workspace-slug}/projects/{project_id}/issue-properties/{property_id}/options/
+api: GET /api/v1/workspaces/{workspace_slug}/projects/{project_id}/issue-properties/{property_id}/options/
 ---
 
 ### Path parameters

--- a/api-reference/issue-types/options/update-dropdown-options.mdx
+++ b/api-reference/issue-types/options/update-dropdown-options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Update property options
 description: Lets you modify existing options within a dropdown property.
-api: PATCH /api/v1/workspaces/{workspace-slug}/projects/{project_id}/issue-properties/{property_id}/options/{option_id}/
+api: PATCH /api/v1/workspaces/{workspace_slug}/projects/{project_id}/issue-properties/{property_id}/options/{option_id}/
 ---
 
 ### Path parameters

--- a/api-reference/issue-types/properties/add-property.mdx
+++ b/api-reference/issue-types/properties/add-property.mdx
@@ -1,7 +1,7 @@
 ---
 title: Add issue properties
 description: Define additional attributes for an issue type in your project. 
-api: POST /api/v1/workspaces/{workspace-slug}/projects/{project_id}/issue-types/{type_id}/issue-properties/
+api: POST /api/v1/workspaces/{workspace_slug}/projects/{project_id}/issue-types/{type_id}/issue-properties/
 ---
 
 ### Path parameters

--- a/api-reference/issue-types/properties/list-properties.mdx
+++ b/api-reference/issue-types/properties/list-properties.mdx
@@ -1,7 +1,7 @@
 ---
 title: List issue properties
 description: Fetches all custom properties associated with a specific issue type in your project.
-api: GET /api/v1/workspaces/{workspace-slug}/projects/{project_id}/issue-types/{type_id}/issue-properties/
+api: GET /api/v1/workspaces/{workspace_slug}/projects/{project_id}/issue-types/{type_id}/issue-properties/
 ---
 
 ### Path parameters

--- a/api-reference/issue-types/values/add-property-values.mdx
+++ b/api-reference/issue-types/values/add-property-values.mdx
@@ -1,7 +1,7 @@
 ---
 title: Add property values
 description: Allows you to specify the values for a custom property.
-api: POST /api/v1/workspaces/{workspace-slug}/projects/{project_id}/issues/{issue_id}/issue-properties/{property_id}/values/
+api: POST /api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/{issue_id}/issue-properties/{property_id}/values/
 ---
 
 ### Path parameters

--- a/api-reference/issue-types/values/list-property-values.mdx
+++ b/api-reference/issue-types/values/list-property-values.mdx
@@ -1,7 +1,7 @@
 ---
 title: List property values
 description: Fetches the values of the custom property. 
-api: GET /api/v1/workspaces/{workspace-slug}/projects/{project_id}/issues/{issue_id}/issue-properties/{property_id}/values/
+api: GET /api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/{issue_id}/issue-properties/{property_id}/values/
 ---
 
 ### Path parameters


### PR DESCRIPTION
### Description
- Because of the typo, api curl is not getting updated with correct slug
- This gives error for the apis

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)