### PR TITLE
Plane-CE: Update environment variable names for clarity and consistency in documentation in Plane CE Docs

### DIFF
--- a/self-hosting/govern/environment-variables.mdx
+++ b/self-hosting/govern/environment-variables.mdx
@@ -166,7 +166,8 @@ The environment configuration file is located at:
 | **WEB_URL** | The complete base URL for the web application including protocol. Essential for email links and integrations. | `http://${APP_DOMAIN}` |
 | **CORS_ALLOWED_ORIGINS** | Comma-separated list of origins allowed to make cross-origin requests to your API. | `http://${APP_DOMAIN}` |
 | **DEBUG** | Toggles debug mode for verbose logging. Set to `1` to enable, `0` to disable. Not recommended in production as it may expose sensitive information. | `0` |
-| **NGINX_PORT** | Port for HTTP traffic. The primary port your users will connect to. | `80` |
+| **LISTEN_HTTP_PORT** | Port for HTTP traffic. The primary port your users will connect to. | `80` |
+| **LISTEN_HTTPS_PORT** | Port for HTTPS traffic. The primary port your users will connect to. | `443` |
 
 ### Scaling and performance
 

--- a/self-hosting/methods/docker-compose.mdx
+++ b/self-hosting/methods/docker-compose.mdx
@@ -101,9 +101,10 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
          This will create a folder `plane-app` or `plane-app-preview` (in case of preview deployment) and will download the `docker-compose.yaml` and `plane.env` files.
       7. Enter `8` to exit.
       8. Set up the environment variables. You can use any text editor to edit this file. Below are the most importants keys you must refer to:
-         - `NGINX_PORT`: This is set to `80` by default. Make sure the port you choose to use is not preoccupied. For example, `NGINX_PORT=8080`
-         - `WEB_URL`: This is set to `http://localhost` by default. Change this to the FQDN you plan to use along with NGINX\_PORT. For example,  `https://plane.example.com:8080` or `http://[IP-ADDRESS]:8080`.
-         - `CORS_ALLOWED_ORIGINS`: This is set to `http://localhost` by default. Change this to the FQDN you plan to use along with NGINX\_PORT. For example, `https://plane.example.com:8080` or `http://[IP-ADDRESS]:8080`.
+         - `LISTEN_HTTP_PORT`: This is set to `80` by default. Make sure the port you choose to use is not preoccupied. For example, `LISTEN_HTTP_PORT=8080`
+         - `LISTEN_HTTPS_PORT`: This is set to `443` by default. Make sure the port you choose to use is not preoccupied. For example, `LISTEN_HTTPS_PORT=4430`
+         - `WEB_URL`: This is set to `http://localhost` by default. Change this to the FQDN you plan to use along with LISTEN_HTTP_PORT. For example,  `https://plane.example.com:8080` or `http://[IP-ADDRESS]:8080`.
+         - `CORS_ALLOWED_ORIGINS`: This is set to `http://localhost` by default. Change this to the FQDN you plan to use along with LISTEN_HTTP_PORT. For example, `https://plane.example.com:8080` or `http://[IP-ADDRESS]:8080`.
       9. Run the following command to continue with the setup.
          ```bash
          ./setup.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated self-hosting docs to replace a single port with separate HTTP/HTTPS port variables and documented their defaults.
  - Clarified WEB_REPLICAS description for the Community Edition.
  - Revised GUNICORN_WORKERS guidance: clarified per-API instance workers and adjusted defaults for Community vs. Production.
  - Updated Docker self-hosting guide to use the new port variables; refreshed references (e.g., WEB_URL, CORS_ALLOWED_ORIGINS) and examples accordingly.
  - Ensured consistency of environment variable names and usage across self-hosting guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->