### PR TITLE
[SILO-607] debug and add configuration mismatch for SILO_BASE_URL in troubleshooting section

### DIFF
--- a/self-hosting/govern/integrations/github.mdx
+++ b/self-hosting/govern/integrations/github.mdx
@@ -144,10 +144,7 @@ To configure GitHub integration, you'll need to create a GitHub App within your 
 
     |Permission&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Access&nbsp;level&nbsp;&nbsp;&nbsp;&nbsp;|Purpose|
     |---------|---------------------|-----------|
-    |Commit statuses|Read-only|Allows the GitHub app to read and update commit statuses, indicating whether a commit has passed checks (e.g., CI/CD pipelines).|
-    |Contents|Read and write|Grants access to read and modify repository contents, including reading files, creating commits, and updating files.|
     |Issues|Read and write|Enables reading, creating, updating, closing, and commenting on issues within the repository.|
-    |Merge queues|Read-only|Allows interaction with merge queues to manage the order of pull request merges.|
     |Metadata|Read-only|Provides read-only access to repository metadata, such as its name, description, and visibility.|
     |Pull requests|Read and write|Allows reading, creating, updating, merging, and commenting on pull requests.|
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- add github troubleshoot section for common errors

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed three repository permission entries from the GitHub integration permissions table (Commit statuses, Contents, Merge queues).
  * Added a comprehensive Troubleshooting section covering invalid private keys, connection failures (org/personal), missing application secret, and reconnection steps.
  * Troubleshooting content now appears in two places on the page for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->