### PR TITLE
Added Airgapped to Editions and updated K8s configurations settings (…

### DIFF
--- a/self-hosting/editions-and-versions.mdx
+++ b/self-hosting/editions-and-versions.mdx
@@ -3,7 +3,7 @@ title: Understanding Plane's editions
 sidebarTitle: Plane's Editions
 ---
 
-Plane comes in three editions by how its deployed. Our Cloud is our only hosted edition as of 2025. Additionally, we offer two unique self-hosted editions tailored to meet two sets of unique needs—the open-source Community Edition and the recommended Commercial Edition.
+Plane comes in four editions by how its deployed. Our Cloud is our only hosted edition as of 2025. Additionally, we offer three unique self-hosted editions tailored to meet two sets of unique needs—the open-source Community Edition, the recommended Commercial Edition, and the Airgapped Edition.
 
 ## About our self-hosted editions
 
@@ -33,6 +33,28 @@ This edition also comes with a Free tier, but also lets you upgrade seamlessly t
 
 - An intuitive upgrade flow that automatically calculates the number of seats you need by the number of users with paid roles in your workspace, so you never have to guess
 
+### Airgapped
+
+Built for organizations with strict security and compliance requirements, the Airgapped Commercial Edition provides the same powerful features as the Commercial Edition but operates in completely isolated environments without internet connectivity.
+
+The Airgapped Edition offers:
+
+- **Complete isolation** 
+Operates entirely within your network perimeter with no external dependencies or outbound connections.
+
+- **Full feature parity** 
+Includes all features available in the standard Commercial Edition, including advanced work management, security controls, and governance tools
+
+- **Version updates** 
+ Updates from your own docker registry.
+
+- **Self-contained architecture** 
+All services, dependencies, and resources are bundled for deployment in restricted networks
+
+- **Compliance-ready** 
+Designed to meet requirements for environments that prohibit external network communication
+
+
 ## Why we separate editions
 
 We’ve designed Plane’s editions to serve diverse user needs while staying true to the ethos of open source.
@@ -40,6 +62,8 @@ We’ve designed Plane’s editions to serve diverse user needs while staying tr
 - The **Community Edition** is completely open-source, with no restrictions beyond those outlined in the [AGPL v3.0 license](https://github.com/makeplane/plane/blob/preview/LICENSE.txt). This is the edition that is now ranking at #1 in our space on GitHub.
 
 - The **Commercial Edition** remains closed-source to offer enterprise-grade features and seamless scalability for businesses.
+
+- The **Airgapped Edition** extends the Commercial Edition's capabilities to isolated environments, ensuring organizations with strict security requirements can still benefit from Plane's full feature set.
 
 Unlike some open-core companies, we’ve adopted a clean separation to keep things simple and transparent. There’s no hidden code that limits modifications on the Community Edition, and no forced migrations from one edition to another.
 
@@ -53,7 +77,7 @@ Each of our editions is built on a distinct codebase. Versions with each differ 
 
 - Be intentful and deliberate with changes to the Community Edition
 
-For both the Commercial and Community Editions, version updates are in your control. Regular updates ensure you’re benefiting from the latest features and improvements. See [Update Plane](/self-hosting/manage/upgrade-plane) for how to upgrade your versions.
+For both the Commercial, Airgapped, and Community Editions, version updates are in your control. Regular updates ensure you’re benefiting from the latest features and improvements. See [Update Plane](/self-hosting/manage/upgrade-plane) for how to upgrade your versions.
 
 
 ## Changelog

--- a/self-hosting/methods/kubernetes.mdx
+++ b/self-hosting/methods/kubernetes.mdx
@@ -26,7 +26,7 @@ Ensure you use use the latest Helm chart version.
     1. Open terminal or any other command-line app that has access to Kubernetes tools on your local system.
     2. Set the following environment variables:
         ```bash
-        PLANE_VERSION=v1.14.1
+        PLANE_VERSION=v1.15.0
         ```
         ```bash
         DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
@@ -83,7 +83,7 @@ Ensure you use use the latest Helm chart version.
             ```
 
             Make sure you set the required environment variables listed below:
-            - `planeVersion: v1.14.1`
+            - `planeVersion: v1.15.0`
             - `license.licenseDomain: <The domain you have specified to host Plane>`
             - `license.licenseServer: https://prime.plane.so`
             - `ingress.enabled: <true | false>`
@@ -113,7 +113,7 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
 
     | Setting | Default | Required | Description |
     |---|:---:|:---:|---|
-    | planeVersion | v1.14.1	 | Yes |  Specifies the version of Plane to be deployed. Copy this from `prime.plane.so.` |
+    | planeVersion | v1.15.0	 | Yes |  Specifies the version of Plane to be deployed. Copy this from `prime.plane.so.` |
     | license.licenseDomain | 'plane.example.com' | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
     #### Airgapped settings
@@ -121,8 +121,8 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | Setting | Default | Required | Description |
     |---|:---:|:---:|---|
     | airgapped.enabled | false | No |  Specifies the airgapped mode the Plane API runs in. |
-    | airgapped.s3SecretName | "s3-custom-ca" | No | Name of the Secret that contains the CA certificate (.crt). The Secret must include a data key whose filename matches the basename of `airgapped.s3SecretKey` (default: `s3-custom-ca.crt`). Used to override S3’s CA when `airgapped.enabled=true`. Applying this secret looks like: `kubectl -n plane create secret generic plane-s3-ca \ --from-file=s3-custom-ca.crt=/path/to/your/ca.crt` | 
-    | airgapped.s3SecretKey | "s3-custom-ca.crt" | No | Key name of the secret to load the Custom Root CA from `airgapped.s3SecretName` |
+    | airgapped.s3SecretName | "" | No | Name of the Secret that contains the CA certificate (.crt). The Secret must include a data key whose filename matches the basename of `airgapped.s3SecretKey` (default: `s3-custom-ca.crt`). Used to override S3’s CA when `airgapped.enabled=true`. Applying this secret looks like: `kubectl -n plane create secret generic plane-s3-ca \ --from-file=s3-custom-ca.crt=/path/to/your/ca.crt` | 
+    | airgapped.s3SecretKey | "" | No | Key name of the secret to load the Custom Root CA from `airgapped.s3SecretName` |
         
 
     #### Postgres
@@ -131,13 +131,19 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     |---|:---:|:---:|---|
     | services.postgres.local_setup | true |  | Plane uses `postgres` as the primary database to store all the transactional data. This database can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws rds or similar services). Set this to  `true` when you choose to setup stateful deployment of `postgres`. Mark it as `false` when using a remotely hosted database |
     | services.postgres.image | `postgres:15.7-alpine` |  | Using this key, user must provide the docker image name to setup the stateful deployment of `postgres`. (must be set when `services.postgres.local_setup=true`)|
+    | services.postgres.pullPolicy | IfNotPresent |  | Using this key, user can set the pull policy for the stateful deployment of postgres. (must be set when `services.postgres.local_setup=true`)|
     | services.postgres.servicePort | 5432 |  | This key sets the default port number to be used while setting up stateful deployment of `postgres`. |
-    | services.postgres.cliConnectPort |  | | If you intend to access the hosted stateful deployment of postgres using any of the client tools (e.g Postico), this key helps you expose the port. The mentioned port must not be occupied by any other applicaiton|
     | services.postgres.volumeSize | 2Gi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
     | env.pgdb_username | plane |  | Database credentials are requried to access the hosted stateful deployment of `postgres`.  Use this key to set the username for the stateful deployment. |
     | env.pgdb_password | plane |  | Database credentials are requried to access the hosted stateful deployment of `postgres`.  Use this key to set the password for the stateful deployment. |
     | env.pgdb_name | plane |  |  Database name to be used while setting up stateful deployment of `Postgres`|
-    | services.postgres.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.postgres.assign_cluster_ip | false |  | This key allows you to set the node selector for the stateful deployment of postgres. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster.|
+    | services.postgres.nodeSelector | {} |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.postgres.tolerations	 | [] |  | This key allows you to set the tolerations for the stateful deployment of postgres. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster.|
+    | services.postgres.affinity | {} |  | This key allows you to set the affinity rules for the stateful deployment of postgres. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.postgres.labels | {} |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.postgres.nodeSelector | {} |  | This key allows you to set custom labels for the stateful deployment of postgres. This is useful for organizing and selecting resources in your Kubernetes cluster.
+    | services.postgres.annotations	 | {} |  | This key allows you to set custom annotations for the stateful deployment of postgres. This is useful for adding metadata or configuration hints to your resources. |
     | env.pgdb_remote_url |  |  | Users can also decide to use the remote hosted database and link to Plane deployment. Ignoring all the above keys, set `services.postgres.local_setup` to `false` and set this key with remote connection url. |
 
     #### Redis/Valkey Setup
@@ -146,9 +152,15 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     |---|:---:|:---:|---|
     | services.redis.local_setup | true |  | Plane uses `redis` to cache the session authentication and other static data. This database can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws rds or similar services). Set this to  `true` when you choose to setup stateful deployment of `redis`. Mark it as `false` when using a remotely hosted database |
     | services.redis.image | `valkey/valkey:7.2.5-alpine` |  | Using this key, user must provide the docker image name to setup the stateful deployment of `redis`. (must be set when `services.redis.local_setup=true`)|
+    | services.redis.pullPolicy	 | IfNotPresent |  | Using this key, user can set the pull policy for the stateful deployment of redis. (must be set when services.redis.local_setup=true) |
     | services.redis.servicePort | 6379 |  | This key sets the default port number to be used while setting up stateful deployment of `redis`. |
     | services.redis.volumeSize | 500Mi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
     | services.redis.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.redis.nodeSelector | 0 |  | This key allows you to set the node selector for the stateful deployment of redis. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.redis.tolerations | [] |  | This key allows you to set the tolerations for the stateful deployment of redis. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.redis.affinity | {}	 |  | This key allows you to set the affinity rules for the stateful deployment of redis. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.redis.labels | {} |  | This key allows you to set custom labels for the stateful deployment of redis. This is useful for organizing and selecting resources in your Kubernetes cluster. |
+    | services.redis.annotations | {} |  | This key allows you to set custom annotations for the stateful deployment of redis. This is useful for adding metadata or configuration hints to your resources. |
     | env.remote_redis_url |  |  | Users can also decide to use the remote hosted database and link to Plane deployment. Ignoring all the above keys, set `services.redis.local_setup` to `false` and set this key with remote connection url. |
 
     #### RabbitMQ Setup
@@ -164,6 +176,11 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | services.rabbitmq.default_user | plane |  | Credentials are requried to access the hosted stateful deployment of `rabbitmq`.  Use this key to set the username for the stateful deployment. |
     | services.rabbitmq.default_password | plane |  | Credentials are requried to access the hosted stateful deployment of `rabbitmq`.  Use this key to set the password for the stateful deployment. |
     | services.rabbitmq.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.rabbitmq.nodeSelector | {} |  | This key allows you to set the node selector for the stateful deployment of rabbitmq. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.rabbitmq.tolerations | [] |  | This key allows you to set the tolerations for the stateful deployment of rabbitmq. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.rabbitmq.affinity | {} |  | This key allows you to set the affinity rules for the stateful deployment of rabbitmq. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.rabbitmq.labels | {} |  | This key allows you to set custom labels for the stateful deployment of rabbitmq. This is useful for organizing and selecting resources in your Kubernetes cluster. |
+    | services.rabbitmq.annotations | {} |  | This key allows you to set custom annotations for the stateful deployment of rabbitmq. This is useful for adding metadata or configuration hints to your resources. |
     | services.rabbitmq.external_rabbitmq_url |  |  | Users can also decide to use the remote hosted service and link to Plane deployment. Ignoring all the above keys, set `services.rabbitmq.local_setup` to `false` and set this key with remote connection url. |
     
     #### Doc Store (Minio\/S3) Setup
@@ -173,12 +190,19 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | services.minio.local_setup | true |  | Plane uses `minio` as the default file storage drive. This storage can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws S3 or similar services). Set this to  `true` when you choose to setup stateful deployment of `minio`. Mark it as `false` when using a remotely hosted database |
     | services.minio.image | minio/minio:latest |  | Using this key, user must provide the docker image name to setup the stateful deployment of `minio`. (must be set when `services.minio.local_setup=true`)|
     | services.minio.image_mc | minio/mc:latest |  | Using this key, user must provide the docker image name to setup the job deployment of `minio client`. (must be set when `services.minio.local_setup=true`)|
+    | services.minio.pullPolicy | services.minio.pullPolicy	 |  | Using this key, user can set the pull policy for the stateful deployment of minio. (must be set when services.minio.local_setup=true) |
     | services.minio.volumeSize | 3Gi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
     | services.minio.root_user | admin |  |  Storage credentials are requried to access the hosted stateful deployment of `minio`.  Use this key to set the username for the stateful deployment. |
     | services.minio.root_password | password |  | Storage credentials are requried to access the hosted stateful deployment of `minio`.  Use this key to set the password for the stateful deployment. |
+    | services.minio.env.minio_endpoint_ssl | false |  | (Optional) Env to enforce HTTPS when connecting to minio uploads bucket |
     | env.docstore_bucket | uploads | Yes | Storage bucket name is required as part of configuration. This is where files will be uploaded irrespective of if you are using `Minio` or external `S3` (or compatible) storage service |
     | env.doc_upload_size_limit | 5242880 | Yes | Document Upload Size Limit (default to 5Mb) |
     | services.minio.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.minio.nodeSelector | {} |  | This key allows you to set the node selector for the stateful deployment of minio. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster.|
+    | services.minio.tolerations | [] |  | This key allows you to set the tolerations for the stateful deployment of minio. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster.|
+    | services.minio.affinity | {} |  | This key allows you to set the affinity rules for the stateful deployment of minio. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.minio.labels | {} |  | This key allows you to set custom labels for the stateful deployment of minio. This is useful for organizing and selecting resources in your Kubernetes cluster. |
+    | services.minio.annotations | {} |  | This key allows you to set custom annotations for the stateful deployment of minio. This is useful for adding metadata or configuration hints to your resources. |
     | env.aws_access_key |  |  | External `S3` (or compatible) storage service provides `access key` for the application to connect and do the necessary upload or download operations. To be provided when `services.minio.local_setup=false`  |
     | env.aws_secret_access_key |  |  | External `S3` (or compatible) storage service provides `secret access key` for the application to connect and do the necessary upload or download operations. To be provided when `services.minio.local_setup=false`  |
     | env.aws_region |  |  | External `S3` (or compatible) storage service providers creates any buckets in user selected region. This is also shared with the user as `region` for the application to connect and do the necessary upload or download operations. To be provided when `services.minio.local_setup=false`  |
@@ -191,8 +215,16 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | services.web.replicas | 1 | Yes | Kubernetes helps you with scaling up or down the deployments. You can run 1 or more pods for each deployment. This key helps you set up the number of replicas you want to run for this deployment. It must be >=1 |
     | services.web.memoryLimit | 1000Mi |  | Every deployment in Kubernetes can be set to use the maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
     | services.web.cpuLimit | 500m |  |  Every deployment in Kubernetes can be set to use the maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+    | services.web.memoryRequest | 50Mi	 |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+    | services.web.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
     | services.web.image| `artifacts.plane.so/makeplane/web-commercial` |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+    | services.web.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of web. |
     | services.web.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.web.nodeSelector	| {} |  | This key allows you to set the node selector for the deployment of web. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.web.tolerations | [] |  | This key allows you to set the tolerations for the deployment of web. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.web.affinity | {} |  | This key allows you to set the affinity rules for the deployment of web. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.web.labels | {} |  | Custom labels to add to the web deployment |
+    | services.web.annotations | {} |  | Custom annotations to add to the web deployment |
 
     #### Space Deployment
 
@@ -201,8 +233,16 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | services.space.replicas | 1 | Yes | Kubernetes helps you with scaling up or down the deployments. You can run 1 or more pods for each deployment. This key helps you set up the number of replicas you want to run for this deployment. It must be >=1 |
     | services.space.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use the maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
     | services.space.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use the maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+    | services.space.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+    | services.space.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
     | services.space.image| `artifacts.plane.so/makeplane/space-commercial` |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+    | services.space.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of space. |
     | services.space.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.space.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of space. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.space.tolerations | [] |  | This key allows you to set the tolerations for the deployment of space. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.space.affinity | {} |  | This key allows you to set the affinity rules for the deployment of space. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.space.labels | {} |  | Custom labels to add to the space deployment |
+    | services.space.annotations | {} |  | Custom annotations to add to the space deployment |
 
     #### Admin Deployment
 
@@ -211,8 +251,16 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | services.admin.replicas | 1 | Yes | Kubernetes helps you with scaling up or down the deployments. You can run 1 or more pods for each deployment. This key helps you set up the number of replicas you want to run for this deployment. It must be >=1 |
     | services.admin.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use the maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
     | services.admin.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use the maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+    | services.admin.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+    | services.admin.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
     | services.admin.image| `artifacts.plane.so/makeplane/admin-commercial` |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+    | services.admin.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of admin. |
     | services.admin.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.admin.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of admin. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.admin.tolerations | []	 |  | This key allows you to set the tolerations for the deployment of admin. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.admin.affinity | {} |  | This key allows you to set the affinity rules for the deployment of admin. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.admin.labels | {} |  | Custom labels to add to the admin deployment. |
+    | services.admin.annotations | {} |  | Custom annotations to add to the admin deployment. |
 
     #### Live Service Deployment
 
@@ -221,11 +269,21 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | services.live.replicas | 1 | Yes | Kubernetes helps you with scaling up\/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
     | services.live.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
     | services.live.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+    | services.live.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+    | services.live.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
     | services.live.image| `artifacts.plane.so/makeplane/live-commercial` |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+    | services.live.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of live. |
     | env.live_sentry_dsn |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry provided DSN for this integration.|
     | env.live_sentry_environment |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration.|
     | env.live_sentry_traces_sample_rate |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry trace sample rate (as configured in Sentry) for this integration.|
-    | services.live.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | env.live_server_secret_key | htbqvBJAgpm9bzvf3r4urJer0ENReatceh |  | Live Server Secret Key |
+    | env.external_iframely_url | "" |  | External Iframely service URL. If provided, the local Iframely deployment will be skipped and the live service will use this external URL |
+    | services.live.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service. |
+    | services.live.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of live. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.live.tolerations | [] |  | This key allows you to set the tolerations for the deployment of live. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.live.affinity | {} |  | This key allows you to set the affinity rules for the deployment of live. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.live.labels | {} |  | Custom labels to add to the live deployment. |
+    | services.live.annotations | {} |  | Custom annotations to add to the live deployment. |
 
     #### Monitor Deployment
 
@@ -233,9 +291,17 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     |---|:---:|:---:|---|
     | services.monitor.memoryLimit | 1000Mi |  | Every deployment in kubernetes can be set to use the maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
     | services.monitor.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use the maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+    | services.monitor.memoryRequest | 50Mi	 |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+    | services.monitor.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
     | services.monitor.image| `artifacts.plane.so/makeplane/monitor-commercial` |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+    | services.monitor.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of monitor. |
     | services.monitor.volumeSize | 100Mi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
     | services.monitor.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.monitor.nodeSelector | {} |  | This key allows you to set the node selector for the stateful deployment of monitor. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.monitor.tolerations | [] |  | This key allows you to set the tolerations for the stateful deployment of monitor. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.monitor.affinity | {} |  | This key allows you to set the affinity rules for the stateful deployment of monitor. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.monitor.labels | {} |  | Custom labels to add to the monitor deployment |
+    | services.monitor.annotations | {} |  | Custom annotations to add to the monitor deployment|
 
     #### API Deployment
 
@@ -244,10 +310,19 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | services.api.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you set up the number of replicas you want to run for this deployment. It must be >=1 |
     | services.api.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use the maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
     | services.api.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use the maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+    | services.api.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+    | services.api.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
     | services.api.image| `artifacts.plane.so/makeplane/backend-commercial` |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+    | services.api.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of api. |
     | env.sentry_dsn |  |  | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry-provided DSN for this integration.|
     | env.sentry_environment |  |  | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration.|
+    | env.api_key_rate_limit | 60/minute |  | (optional) User can set the maximum number of requests the API can handle in a given time frame. |
     | services.api.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+    | services.api.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of api. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.api.tolerations | [] |  | This key allows you to set the tolerations for the deployment of api. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.api.affinity | {} |  | This key allows you to set the affinity rules for the deployment of api. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.api.labels | {} |  | Custom labels to add to the API deployment |
+    | services.api.annotations | {} |  | Custom annotations to add to the API deployment |
 
     #### Silo Deployment
 
@@ -256,9 +331,16 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | services.silo.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
     | services.silo.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
     | services.silo.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+    | services.silo.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+    | services.silo.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
     | services.silo.image| `artifacts.plane.so/makeplane/silo-commercial` |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
     | services.silo.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `silo`. |
     | services.silo.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service | 
+    | services.silo.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of silo. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.silo.tolerations | [] |  | This key allows you to set the tolerations for the deployment of silo. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.silo.affinity | {} |  | This key allows you to set the affinity rules for the deployment of silo. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.silo.labels | {} |  | Custom labels to add to the silo deployment |
+    | services.silo.annotations	 | {} |  | Custom annotations to add to the silo deployment |
     | services.silo.connectors.slack.enabled | false |  | Slack Integration |
     | services.silo.connectors.slack.client_id | "" | required if `services.silo.connectors.slack.enabled` is `true` | Slack Client ID |
     | services.silo.connectors.slack.client_secret | "" | required if `services.silo.connectors.slack.enabled` is `true` | Slack Client Secret |
@@ -278,6 +360,7 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | env.silo_envs.sentry_environment |  |  | Sentry Environment |
     | env.silo_envs.sentry_traces_sample_rate |  |  | Sentry Traces Sample Rate | 
     | env.silo_envs.hmac_secret_key |  &lt;random-32-bit-string&gt; |  | HMAC Secret Key |
+    | env.silo_envs.aes_secret_key |  "dsOdt7YrvxsTIFJ37pOaEVvLxN8KGBCr" |  | AES Secret Key |
         
     #### Worker Deployment
 
@@ -286,6 +369,13 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | services.worker.replicas | 1 | Yes | Kubernetes helps you with scaling up or down the deployments. You can run 1 or more pods for each deployment. This key helps you set up the number of replicas you want to run for this deployment. It must be >=1 |
     | services.worker.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use the maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
     | services.worker.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use the maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
+    | services.worker.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
+    | services.worker.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
+    | services.worker.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of worker. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster.|
+    | services.worker.tolerations | [] |  | This key allows you to set the tolerations for the deployment of worker. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster.|
+    | services.worker.affinity | {} |  | This key allows you to set the affinity rules for the deployment of worker. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster.|
+    | services.worker.labels | {} |  | Custom labels to add to the worker deployment |
+    | services.worker.annotations | {} |  | Custom annotations to add to the worker deployment |
 
     #### Beat-Worker Deployment
 
@@ -294,62 +384,160 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     | services.beatworker.replicas | 1 | Yes | Kubernetes helps you with scaling up or down the deployments. You can run 1 or more pods for each deployment. This key helps you set up the number of replicas you want to run for this deployment. It must be >=1 |
     | services.beatworker.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use the maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
     | services.beatworker.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use the maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-    
+    | services.beatworker.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
+    | services.beatworker.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
+    | services.beatworker.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of beatworker. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.beatworker.tolerations | [] |  | This key allows you to set the tolerations for the deployment of beatworker. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.beatworker.affinity | {} |  | This key allows you to set the affinity rules for the deployment of beatworker. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.beatworker.labels | {} |  | Custom labels to add to the beat-worker deployment |
+    | services.beatworker.annotations | {} |  | Custom annotations to add to the beat-worker deployment |
+
+    #### Email Service Deployment
+
+    | Setting | Default | Required | Description |
+    |---------|---------|----------|-------------|
+    | services.email_service.enabled | false | | Set to `true` to enable the email service deployment |
+    | services.email_service.replicas | 1 | | Number of replicas for the email service deployment |
+    | services.email_service.memoryLimit | 1000Mi | | Memory limit for the email service deployment |
+    | services.email_service.cpuLimit | 500m | | CPU limit for the email service deployment |
+    | services.email_service.memoryRequest | 50Mi | | Memory request for the email service deployment |
+    | services.email_service.cpuRequest | 50m | | CPU request for the email service deployment |
+    | services.email_service.image | artifacts.plane.so/makeplane/email-commercial | | Docker image for the email service deployment |
+    | services.email_service.pullPolicy | Always | | Image pull policy for the email service deployment |
+    | services.email_service.nodeSelector | {} | | This key allows you to set the node selector for the deployment of `email_service`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.email_service.tolerations | [] | | This key allows you to set the tolerations for the deployment of `email_service`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.email_service.affinity | {} | | This key allows you to set the affinity rules for the deployment of `email_service`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.email_service.labels | {} | | Custom labels to add to the email service deployment |
+    | services.email_service.annotations | {} | | Custom annotations to add to the email service deployment |
+    | env.email_service_envs.smtp_domain | | Yes | The SMTP Domain to be used with email service |                                         |          |                                                          |
+
+    #### Outbox Poller Service Deployment
+
+    | Setting | Default | Required | Description |
+    |---------|---------|----------|-------------|
+    | services.outbox_poller.enabled | false | | Set to true to enable the outbox poller service deployment |
+    | services.outbox_poller.replicas | 1 | | Number of replicas for the outbox poller service deployment |
+    | services.outbox_poller.memoryLimit | 1000Mi | | Memory limit for the outbox poller service deployment |
+    | services.outbox_poller.cpuLimit | 500m | | CPU limit for the outbox poller service deployment |
+    | services.outbox_poller.memoryRequest | 50Mi | | Memory request for the outbox poller service deployment |
+    | services.outbox_poller.cpuRequest | 50m | | CPU request for the outbox poller service deployment |
+    | services.outbox_poller.pullPolicy | Always | | Image pull policy for the outbox poller service deployment |
+    | services.outbox_poller.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+    | services.outbox_poller.nodeSelector | {} | | This key allows you to set the node selector for the deployment of outbox_poller. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.outbox_poller.tolerations | [] | | This key allows you to set the tolerations for the deployment of outbox_poller. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.outbox_poller.affinity | {} | | This key allows you to set the affinity rules for the deployment of outbox_poller. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.outbox_poller.labels | {} | | Custom labels to add to the outbox poller deployment |
+    | services.outbox_poller.annotations | {} | | Custom annotations to add to the outbox poller deployment |
+    | env.outbox_poller_envs.memory_limit_mb | 400 | | Memory limit in MB for the outbox poller |
+    | env.outbox_poller_envs.interval_min | 0.25 | | Minimum interval in minutes for polling |
+    | env.outbox_poller_envs.interval_max | 2 | | Maximum interval in minutes for polling |
+    | env.outbox_poller_envs.batch_size | 250 | | Batch size for processing outbox messages |
+    | env.outbox_poller_envs.memory_check_interval | 30 | | Memory check interval in seconds |
+    | env.outbox_poller_envs.pool.size | 4 | | Pool size for database connections |
+    | env.outbox_poller_envs.pool.min_size | 2 | | Minimum pool size for database connections |
+    | env.outbox_poller_envs.pool.max_size | 10 | | Maximum pool size for database connections |
+    | env.outbox_poller_envs.pool.timeout | 30.0 | | Pool timeout in seconds |
+    | env.outbox_poller_envs.pool.max_idle | 300.0 | | Maximum idle time for connections in seconds |
+    | env.outbox_poller_envs.pool.max_lifetime | 3600 | | Maximum lifetime for connections in seconds |
+    | env.outbox_poller_envs.pool.reconnect_timeout | 5.0 | | Reconnect timeout in seconds |
+    | env.outbox_poller_envs.pool.health_check_interval | 60 | | Health check interval in seconds |
+
+    #### Automation Consumer Deployment
+
+    | Setting | Default | Required | Description |
+    |---------|---------|----------|-------------|
+    | services.automation_consumer.enabled | false | | Set to true to enable the automation consumer service deployment |
+    | services.automation_consumer.replicas | 1 | | Number of replicas for the automation consumer service deployment |
+    | services.automation_consumer.memoryLimit | 1000Mi | | Memory limit for the automation consumer service deployment |
+    | services.automation_consumer.cpuLimit | 500m | | CPU limit for the automation consumer service deployment |
+    | services.automation_consumer.memoryRequest | 50Mi | | Memory request for the automation consumer service deployment |
+    | services.automation_consumer.cpuRequest | 50m | | CPU request for the automation consumer service deployment |
+    | services.automation_consumer.pullPolicy | Always | | Image pull policy for the automation consumer service deployment |
+    | services.automation_consumer.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+    | services.automation_consumer.nodeSelector | {} | | This key allows you to set the node selector for the deployment of automation_consumer. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.automation_consumer.tolerations | [] | | This key allows you to set the tolerations for the deployment of automation_consumer. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.automation_consumer.affinity | {} | | This key allows you to set the affinity rules for the deployment of automation_consumer. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.automation_consumer.labels | {} | | Custom labels to add to the automation consumer deployment |
+    | services.automation_consumer.annotations | {} | | Custom annotations to add to the automation consumer deployment |
+    | env.automation_consumer_envs.event_stream_queue_name | "plane.event_stream.automations" | | Event stream queue name for automations |
+    | env.automation_consumer_envs.event_stream_prefetch | 10 | | Event stream prefetch count |
+    | env.automation_consumer_envs.exchange_name | "plane.event_stream" | | Exchange name for event stream |
+    | env.automation_consumer_envs.event_types | "issue" | | Event types to process |
+
+    #### Iframely Deployment
+
+    | Setting | Default | Required | Description |
+    |---------|---------|----------|-------------|
+    | services.iframely.enabled | false | | Set to true to enable the Iframely service deployment |
+    | services.iframely.replicas | 1 | | Number of replicas for the Iframely service deployment |
+    | services.iframely.memoryLimit | 1000Mi | | Memory limit for the Iframely service deployment |
+    | services.iframely.cpuLimit | 500m | | CPU limit for the Iframely service deployment |
+    | services.iframely.memoryRequest | 50Mi | | Memory request for the Iframely service deployment |
+    | services.iframely.cpuRequest | 50m | | CPU request for the Iframely service deployment |
+    | services.iframely.image | artifacts.plane.so/makeplane/iframely:v1.2.0 | | Docker image for the Iframely service deployment |
+    | services.iframely.pullPolicy | Always | | Image pull policy for the Iframely service deployment |
+    | services.iframely.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+    | services.iframely.nodeSelector | {} | | This key allows you to set the node selector for the deployment of iframely. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+    | services.iframely.tolerations | [] | | This key allows you to set the tolerations for the deployment of iframely. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+    | services.iframely.affinity | {} | | This key allows you to set the affinity rules for the deployment of iframely. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+    | services.iframely.labels | {} | | Custom labels to add to the iframely deployment |
+    | services.iframely.annotations | {} | | Custom annotations to add to the iframely deployment |
+
     #### External Secrets Config
 
-    To configure the external secrets for your application, you need to define specific environment variables for each secret category. Below is a list of the required secrets and their respective environment variables. See [External secrets](/self-hosting/govern/external-secrets) for setup details. 
-    
+    To configure the external secrets for your application, you need to define specific environment variables for each secret category. Below is a list of the required secrets and their respective environment variables.
+
     | Secret Name | Env Var Name | Required | Description | Example Value |
-    |--- |:---|:---|:---|:---|
-    | rabbitmq_existingSecret     | `RABBITMQ_DEFAULT_USER`  | Required if `rabbitmq.local_setup=true` | The default RabbitMQ user                    | `plane`      |
-    |                      | `RABBITMQ_DEFAULT_PASS`  | Required if `rabbitmq.local_setup=true` | The default RabbitMQ password                | `plane`      |
-    | pgdb_existingSecret         | `POSTGRES_PASSWORD`      | Required if `postgres.local_setup=true` | Password for PostgreSQL database             | `plane`   |
-    |                      | `POSTGRES_DB`            | Required if `postgres.local_setup=true` | Name of the PostgreSQL database              | `plane`      |
-    |                      | `POSTGRES_USER`          | Required if `postgres.local_setup=true` | PostgreSQL user                              | `plane`       |
-    |  doc_store_existingSecret                 | `USE_MINIO`              | Yes | Flag to enable MinIO as the storage backend  | `1`         |
-    |                      | `MINIO_ROOT_USER`        | Yes | MinIO root user                              | `admin`    |
-    |     | `MINIO_ROOT_PASSWORD`    | Yes | MinIO root password                          | `password`    |
-    |                      | `AWS_ACCESS_KEY_ID`      | Yes | AWS Access Key ID                            | `your_aws_key`       |
-    |                      | `AWS_SECRET_ACCESS_KEY`  | Yes | AWS Secret Access Key                        | `your_aws_secret`    |
-    |                      | `AWS_S3_BUCKET_NAME`     | Yes | AWS S3 Bucket Name                           | `your_bucket_name`   |
-    |                      | `AWS_S3_ENDPOINT_URL`    | Yes | Endpoint URL for AWS S3 or MinIO             | `http://plane-minio.plane-ns.svc.cluster.local:9000`  |
-    |                      | `AWS_REGION`             | Optional | AWS region where your S3 bucket is located   | `your_aws_region`    |
-    |                      | `FILE_SIZE_LIMIT`        | Yes | Limit for file uploads in your system        | `5MB`               |
-    | app_env_existingSecret      | `SECRET_KEY`             | Yes | Random secret key                            | `60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5`  |
-    |                      | `REDIS_URL`              | Yes | Redis URL                                    | `redis://plane-redis.plane-ns.svc.cluster.local:6379/`  |
-    |                      | `DATABASE_URL`           | Yes | PostgreSQL connection URL                    | **k8s service example**: `postgresql://plane:plane@plane-pgdb.plane-ns.svc.cluster.local:5432/plane` <br/> <br/>**external service example**: `postgresql://username:password@your-db-host:5432/plane` |
-    |                      | `AMQP_URL`               | Yes | RabbitMQ connection URL                      | **k8s service example**: `amqp://plane:plane@plane-rabbitmq.plane-ns.svc.cluster.local:5672/`  <br/> <br/> **external service example**: `amqp://username:password@your-rabbitmq-host:5672/` |
-    | live_env_existingSecret    | `REDIS_URL`              | Yes | Redis URL                                    | `redis://plane-redis.plane-ns.svc.cluster.local:6379/`  |
-    | silo_env_existingSecret    | `SILO_HMAC_SECRET_KEY`       | Yes | Silo HMAC secret Key                             | `<random-32-bit-string>`|
-    |     | `REDIS_URL`              | Yes | Redis URL                                    | `redis://plane-redis.plane-ns.svc.cluster.local:6379/`  |
-    |                            | `DATABASE_URL`           | Yes | PostgreSQL connection URL                    |  **k8s service example**: `postgresql://plane:plane@plane-pgdb.plane-ns.svc.cluster.local:5432/plane` <br/> <br/>**external service example**: `postgresql://username:password@your-db-host:5432/plane`|
-    |                            | `AMQP_URL`               | Yes | RabbitMQ connection URL                      | **k8s service example**: `amqp://plane:plane@plane-rabbitmq.plane-ns.svc.cluster.local:5672/`  <br/> <br/> **external service example**: `amqp://username:password@your-rabbitmq-host:5672/`  |
-    |                            | `GITHUB_APP_NAME`        | required if `services.silo.connectors.github.enabled` is `true` | GitHub app name                              | `your_github_app_name`|
-    |                            | `GITHUB_APP_ID`          | required if `services.silo.connectors.github.enabled` is `true` | GitHub app ID                                | `your_github_app_id`|
-    |                            | `GITHUB_CLIENT_ID`       | required if `services.silo.connectors.github.enabled` is `true` | GitHub client ID                             | `your_github_client_id`|
-    |                            | `GITHUB_CLIENT_SECRET` | required if `services.silo.connectors.github.enabled` is `true` | GitHub client secret key                     | `your_github_client_secret_key`|
-    |                            | `GITHUB_PRIVATE_KEY`     | required if `services.silo.connectors.github.enabled` is `true` | GitHub private key                           | `your_github_private_key`|
-    |                            | `SLACK_CLIENT_ID`        | required if `services.silo.connectors.slack.enabled` is `true` | Slack client ID                              | `your_slack_client_id`|
-    |                            | `SLACK_CLIENT_SECRET` | required if `services.silo.connectors.slack.enabled` is `true` | Slack client secret key                      | `your_slack_client_secret_key`|
-    |                            | `GITLAB_CLIENT_ID`      | required if `services.silo.connectors.gitlab.enabled` is `true` | GitLab client ID                             | `your_gitlab_client_id`|
-    |                            | `GITLAB_CLIENT_SECRET` | required if `services.silo.connectors.gitlab.enabled` is `true` | GitLab client secret key                     | `your_gitlab_client_secret_key`|
-  
+    |-------------|--------------|----------|-------------|---------------|
+    | rabbitmq_existingSecret | RABBITMQ_DEFAULT_USER | Required if `rabbitmq.local_setup=true` | The default RabbitMQ user | plane |
+    | | RABBITMQ_DEFAULT_PASS | Required if `rabbitmq.local_setup=true` | The default RabbitMQ password | plane |
+    | pgdb_existingSecret | POSTGRES_PASSWORD | Required if `postgres.local_setup=true` | Password for PostgreSQL database | plane |
+    | | POSTGRES_DB | Required if `postgres.local_setup=true` | Name of the PostgreSQL database | plane |
+    | | POSTGRES_USER | Required if `postgres.local_setup=true` | PostgreSQL user | plane |
+    | doc_store_existingSecret | USE_MINIO | Yes | Flag to enable MinIO as the storage backend | 1 |
+    | | MINIO_ROOT_USER | Yes | MinIO root user | admin |
+    | | MINIO_ROOT_PASSWORD | Yes | MinIO root password | password |
+    | | AWS_ACCESS_KEY_ID | Yes | AWS Access Key ID | your_aws_key |
+    | | AWS_SECRET_ACCESS_KEY | Yes | AWS Secret Access Key | your_aws_secret |
+    | | AWS_S3_BUCKET_NAME | Yes | AWS S3 Bucket Name | your_bucket_name |
+    | | AWS_S3_ENDPOINT_URL | Yes | Endpoint URL for AWS S3 or MinIO | `http://plane-minio.plane-ns.svc.cluster.local:9000` |
+    | | AWS_REGION | Optional | AWS region where your S3 bucket is located | your_aws_region |
+    | | FILE_SIZE_LIMIT | Yes | Limit for file uploads in your system | 5MB |
+    | app_env_existingSecret | SECRET_KEY | Yes | Random secret key | 60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5 |
+    | | REDIS_URL | Yes | Redis URL | `redis://plane-redis.plane-ns.svc.cluster.local:6379/` |
+    | | DATABASE_URL | Yes | PostgreSQL connection URL | k8s service example: `postgresql://plane:plane@plane-pgdb.plane-ns.svc.cluster.local:5432/plane` external service example: `postgresql://username:password@your-db-host:5432/plane` |
+    | | AMQP_URL | Yes | RabbitMQ connection URL | k8s service example: `amqp://plane:plane@plane-rabbitmq.plane-ns.svc.cluster.local:5672/` external service example: `amqp://username:password@your-rabbitmq-host:5672/` |
+    | live_env_existingSecret | REDIS_URL | Yes | Redis URL | `redis://plane-redis.plane-ns.svc.cluster.local:6379/` |
+    | silo_env_existingSecret | SILO_HMAC_SECRET_KEY | Yes | Silo HMAC secret Key | `<random-32-bit-string>` |
+    | | REDIS_URL | Yes | Redis URL | redis://plane-redis.plane-ns.svc.cluster.local:6379/ |
+    | | DATABASE_URL | Yes | PostgreSQL connection URL | k8s service example: postgresql://plane:plane@plane-pgdb.plane-ns.svc.cluster.local:5432/plane  external service example: postgresql://username:password@your-db-host:5432/plane |
+    | | AMQP_URL | Yes | RabbitMQ connection URL | k8s service example: amqp://plane:plane@plane-rabbitmq.plane-ns.svc.cluster.local:5672/  external service example: amqp://username:password@your-rabbitmq-host:5672/ |
+    | | GITHUB_APP_NAME | Required if services.silo.connectors.github.enabled is true | GitHub app name | your_github_app_name |
+    | | GITHUB_APP_ID | Required if services.silo.connectors.github.enabled is true | GitHub app ID | your_github_app_id |
+    | | GITHUB_CLIENT_ID | Required if services.silo.connectors.github.enabled is true | GitHub client ID | your_github_client_id |
+    | | GITHUB_CLIENT_SECRET | Required if services.silo.connectors.github.enabled is true | GitHub client secret key | your_github_client_secret_key |
+    | | GITHUB_PRIVATE_KEY | Required if services.silo.connectors.github.enabled is true | GitHub private key | your_github_private_key |
+    | | SLACK_CLIENT_ID | Required if services.silo.connectors.slack.enabled is true | Slack client ID | your_slack_client_id |
+    | | SLACK_CLIENT_SECRET | Required if services.silo.connectors.slack.enabled is true | Slack client secret key | your_slack_client_secret_key |
+    | | GITLAB_CLIENT_ID | Required if services.silo.connectors.gitlab.enabled is true | GitLab client ID | your_gitlab_client_id |
+    | | GITLAB_CLIENT_SECRET | Required if services.silo.connectors.gitlab.enabled is true | GitLab client secret key | your_gitlab_client_secret_key |
     
     #### Ingress and SSL Setup
 
     | Setting | Default | Required | Description |
-    |---|:---:|:---:|---|
-    | ingress.enabled | true |  | Ingress setup in kubernetes is a common practice to expose the application to the intended audience.  Set it to `false` if you are using an external ingress providers like `Cloudflare` |
-    | ingress.minioHost | 'plane-services.minio.example.com' |  | Based on the above configuration, if you want to expose the `minio` web console to a set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose the interface. |
-    | ingress.ingressClass | 'nginx' | Yes | Kubernetes cluster setup comes with various options of `ingressClass`. Based on your setup, set this value to the right one (eg. nginx, traefik, etc). Leave it to default in case you are using an external ingress provider.|
-    | ingress.ingress_annotations | `{ "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }` |  | Ingress controllers come with various configuration options which can be passed as annotations. Setting this value lets you change the default value to user required. |
-    | ssl.createIssuer | false |  | Kubernets cluster setup supports creating `issuer` type resource. After deployment, this is the step towards creating secure access to the ingress url. Issuer is required for you to generate SSL certificate. Kubernetes can be configured to use any certificate authority to generate SSL (depending on CertManager configuration). Set it to `true` to create the issuer. Applicable only when `ingress.enabled=true`|
-    | ssl.issuer | http |  | CertManager configuration allows user to create issuers using `http` or any of the other DNS Providers like `cloudflare`, `digitalocean`, etc. As of now, Plane supports `http`, `cloudflare`, `digitalocean`|
-    | ssl.token |  |  | To create issuers using DNS challenge, set the issuer api token of dns provider like cloudflare` or `digitalocean`(not required for http) |
-    | ssl.server | `https://acme-v02.api.letsencrypt.org/directory` |  | Issuer creation configuration needs the certificate generation authority server url. Default URL is the `Let's Encrypt` server|
-    | ssl.email | `plane@example.com` |  | Certificate generation authority needs a valid email id before generating certificate. Required when `ssl.createIssuer=true`  |
-    | ssl.generateCerts | false |  | After creating the issuers, the user can still not create the certificate until sure of the configuration. Setting this to `true` will try to generate SSL certificate and associate with ingress. Applicable only when `ingress.enabled=true` and `ssl.createIssuer=true` |
-    | ssl.tls_secret_name |  |  | If you have a custom TLS secret name, set this to the name of the secret. Applicable only when `ingress.enabled=true` and `ssl.createIssuer=false` |
+    |---------|---------|----------|-------------|
+    | ingress.enabled | true | | Ingress setup in kubernetes is a common practice to expose application to the intended audience. Set it to false if you are using external ingress providers like Cloudflare |
+    | ingress.minioHost | | | Based on above configuration, if you want to expose the minio web console to set of users, use this key to set the host mapping or leave it as EMPTY to not expose interface. |
+    | ingress.rabbitmqHost | | | Based on above configuration, if you want to expose the rabbitmq web console to set of users, use this key to set the host mapping or leave it as EMPTY to not expose interface. |
+    | ingress.ingressClass | nginx | Yes | Kubernetes cluster setup comes with various options of ingressClass. Based on your setup, set this value to the right one (eg. nginx, traefik, etc). Leave it to default in case you are using external ingress provider. |
+    | ingress.ingress_annotations | { `"nginx.ingress.kubernetes.io/proxy-body-size": "5m"` } | | Ingress controllers comes with various configuration options which can be passed as annotations. Setting this value lets you change the default value to user required. |
+    | ssl.createIssuer | false | | Kubernets cluster setup supports creating issuer type resource. After deployment, this is step towards creating secure access to the ingress url. Issuer is required for you generate SSL certifiate. Kubernetes can be configured to use any of the certificate authority to generate SSL (depending on CertManager configuration). Set it to true to create the issuer. Applicable only when ingress.enabled=true |
+    | ssl.issuer | http | | CertManager configuration allows user to create issuers using http or any of the other DNS Providers like cloudflare, digitalocean, etc. As of now Plane supports http, cloudflare, digitalocean |
+    | ssl.token | | | To create issuers using DNS challenge, set the issuer api token of dns provider like cloudflare or digitalocean (not required for http) |
+    | ssl.server | | | Issuer creation configuration need the certificate generation authority server url. Default URL is the Let's Encrypt server |
+    | ssl.email | plane@example.com | | Certificate generation authority needs a valid email id before generating certificate. Required when ssl.createIssuer=true |
+    | ssl.generateCerts | false | | After creating the issuers, user can still not create the certificate untill sure of configuration. Setting this to true will try to generate SSL certificate and associate with ingress. Applicable only when ingress.enabled=true and ssl.createIssuer=true |
+    | ssl.tls_secret_name | | | If you have a custom TLS secret name, set this to the name of the secret. Applicable only when ingress.enabled=true and ssl.createIssuer=false |
 
     #### Common Environment Settings
 
@@ -357,6 +545,12 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
     |---|:---:|:---:|---|
     | env.storageClass | longhorn |  | Creating the persitant volumes for the stateful deployments needs the `storageClass` name. Set the correct value as per your kubernetes cluster configuration. |
     | env.secret_key | 60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5 | Yes | This must be a random string which is used for hashing/encrypting the sensitive data within the application. Once set, changing this might impact the already hashed/encrypted data|
+
+    #### Extra Environment Variables
+
+    | Setting | Default | Required | Description |
+    |---------|---------|----------|-------------|
+    | extraEnv | [] | No | Global extra environment variables that will be applied to all workloads. This allows you to add custom environment variables to all deployments (web, api, worker, etc.). Useful for proxy settings, custom configurations, or any environment-specific variables. Some example variables are HTTP_PROXY, HTTPS_PROXY, NO_PROXY. |
 
 ## Custom Ingress Routes
 
@@ -450,201 +644,225 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
         #### Plane Version
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | planeVersion | stable | Yes |  |
+        |---------|---------|----------|-------------|
+        | planeVersion | v1.1.0 | Yes | |
 
         #### Postgres DB Setup
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | postgres.local_setup | true |  | Plane uses `postgres` as the primary database to store all the transactional data. This database can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws rds or similar services). Set this to  `true` when you choose to setup stateful deployment of `postgres`. Mark it as `false` when using a remotely hosted database |
-        | postgres.image | postgres:15.7-alpine |  | Using this key, user must provide the docker image name to setup the stateful deployment of `postgres`. (must be set when `postgres.local_setup=true`)|
-        | postgres.pullPolicy | IfNotPresent |  | Using this key, user can set the pull policy for the stateful deployment of `postgres`. (must be set when `postgres.local_setup=true`)|
-        | postgres.servicePort | 5432 |  | This key sets the default port number to be used while setting up stateful deployment of `postgres`. |
-        | postgres.volumeSize | 5Gi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
-        | env.pgdb_username | plane |  | Database credentials are requried to access the hosted stateful deployment of `postgres`.  Use this key to set the username for the stateful deployment. |
-        | env.pgdb_password | plane |  | Database credentials are requried to access the hosted stateful deployment of `postgres`.  Use this key to set the password for the stateful deployment. |
-        | env.pgdb_name | plane |  |  Database name to be used while setting up stateful deployment of `Postgres`|
-        | env.pgdb_remote_url |  |  | Users can also decide to use the remote hosted database and link to Plane deployment. Ignoring all the above keys, set `postgres.local_setup` to `false` and set this key with remote connection url. |
-        | postgres.storageClass | &lt;k8s-default-storage-class&gt; |  | Creating the persitant volumes for the stateful deployments needs the `storageClass` name. Set the correct value as per your kubernetes cluster configuration. |
-        | postgres.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+        |---------|---------|----------|-------------|
+        | postgres.local_setup | true | | Plane uses postgres as the primary database to store all the transactional data. This database can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws rds or similar services). Set this to true when you choose to setup stateful deployment of postgres. Mark it as false when using a remotely hosted database |
+        | postgres.image | postgres:15.7-alpine | | Using this key, user must provide the docker image name to setup the stateful deployment of postgres. (must be set when `postgres.local_setup=true`) |
+        | postgres.pullPolicy | IfNotPresent | | Using this key, user can set the pull policy for the stateful deployment of postgres. (must be set when `postgres.local_setup=true`) |
+        | postgres.servicePort | 5432 | | This key sets the default port number to be used while setting up stateful deployment of postgres. |
+        | postgres.volumeSize | 5Gi | | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
+        | env.pgdb_username | plane | | Database credentials are requried to access the hosted stateful deployment of postgres. Use this key to set the username for the stateful deployment. |
+        | env.pgdb_password | plane | | Database credentials are requried to access the hosted stateful deployment of postgres. Use this key to set the password for the stateful deployment. |
+        | env.pgdb_name | plane | | Database name to be used while setting up stateful deployment of Postgres |
+        | env.pgdb_remote_url | | | Users can also decide to use the remote hosted database and link to Plane deployment. Ignoring all the above keys, set postgres.local_setup to false and set this key with remote connection url. |
+        | postgres.storageClass | `<k8s-default-storage-class>` | | Creating the persitant volumes for the stateful deployments needs the storageClass name. Set the correct value as per your kubernetes cluster configuration. |
+        | postgres.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+        | postgres.nodeSelector | {} | | This key allows you to set the node selector for the stateful deployment of postgres. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | postgres.tolerations | [] | | This key allows you to set the tolerations for the stateful deployment of postgres. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | postgres.affinity | {} | | This key allows you to set the affinity rules for the stateful deployment of postgres. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | postgres.labels | {} | | This key allows you to set custom labels for the stateful deployment of postgres. This is useful for organizing and selecting resources in your Kubernetes cluster. |
+        | postgres.annotations | {} | | This key allows you to set custom annotations for the stateful deployment of postgres. This is useful for adding metadata or configuration hints to your resources. |
 
         #### Redis/Valkey Setup
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | redis.local_setup | true |  | Plane uses `redis` to cache the session authentication and other static data. This database can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws rds or similar services). Set this to  `true` when you choose to setup stateful deployment of `redis`. Mark it as `false` when using a remotely hosted database |
-        | redis.image | valkey/valkey:7.2.5-alpine |  | Using this key, user must provide the docker image name to setup the stateful deployment of `redis`. (must be set when `redis.local_setup=true`)|
-        | redis.pullPolicy | IfNotPresent |  | Using this key, user can set the pull policy for the stateful deployment of `redis`. (must be set when `redis.local_setup=true`)|
-        | redis.servicePort | 6379 |  | This key sets the default port number to be used while setting up stateful deployment of `redis`. |
-        | redis.volumeSize | 1Gi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
-        | env.remote_redis_url |  |  | Users can also decide to use the remote hosted database and link to Plane deployment. Ignoring all the above keys, set `redis.local_setup` to `false` and set this key with remote connection url. |
-        | redis.storageClass | &lt;k8s-default-storage-class&gt; |  | Creating the persitant volumes for the stateful deployments needs the `storageClass` name. Set the correct value as per your kubernetes cluster configuration. |
-        | redis.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+        |---------|---------|----------|-------------|
+        | redis.local_setup | true | | Plane uses redis to cache the session authentication and other static data. This database can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws rds or similar services). Set this to true when you choose to setup stateful deployment of redis. Mark it as false when using a remotely hosted database |
+        | redis.image | `valkey/valkey:7.2.5-alpine` | | Using this key, user must provide the docker image name to setup the stateful deployment of redis. (must be set when redis.local_setup=true) |
+        | redis.pullPolicy | IfNotPresent | | Using this key, user can set the pull policy for the stateful deployment of redis. (must be set when `redis.local_setup=true`) |
+        | redis.servicePort | 6379 | | This key sets the default port number to be used while setting up stateful deployment of redis. |
+        | redis.volumeSize | 1Gi | | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
+        | env.remote_redis_url | | | Users can also decide to use the remote hosted database and link to Plane deployment. Ignoring all the above keys, set redis.local_setup to false and set this key with remote connection url. |
+        | redis.storageClass | `<k8s-default-storage-class>` | | Creating the persitant volumes for the stateful deployments needs the storageClass name. Set the correct value as per your kubernetes cluster configuration. |
+        | redis.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+        | redis.nodeSelector | {} | | This key allows you to set the node selector for the stateful deployment of redis. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | redis.tolerations | [] | | This key allows you to set the tolerations for the stateful deployment of redis. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | redis.affinity | {} | | This key allows you to set the affinity rules for the stateful deployment of redis. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | redis.labels | {} | | This key allows you to set custom labels for the stateful deployment of redis. This is useful for organizing and selecting resources in your Kubernetes cluster. |
+        | redis.annotations | {} | | This key allows you to set custom annotations for the stateful deployment of redis. This is useful for adding metadata or configuration hints to your resources. |
 
         #### RabbitMQ Setup
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | rabbitmq.local_setup | true |  | Plane uses `rabbitmq` as message queuing system. This can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws mq or similar services). Set this to  `true` when you choose to setup stateful deployment of `rabbitmq`. Mark it as `false` when using a remotely hosted service |
-        | rabbitmq.image | rabbitmq:3.13.6-management-alpine |  | Using this key, user must provide the docker image name to setup the stateful deployment of `rabbitmq`. (must be set when `rabbitmq.local_setup=true`)|
-        | rabbitmq.pullPolicy | IfNotPresent |  | Using this key, user can set the pull policy for the stateful deployment of `rabbitmq`. (must be set when `rabbitmq.local_setup=true`)|
-        | rabbitmq.servicePort | 5672 |  | This key sets the default port number to be used while setting up stateful deployment of `rabbitmq`. |
-        | rabbitmq.managementPort | 15672 |  | This key sets the default management port number to be used while setting up stateful deployment of `rabbitmq`. |
-        | rabbitmq.volumeSize | 100Mi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
-        | rabbitmq.storageClass | &lt;k8s-default-storage-class&gt; |  | Creating the persitant volumes for the stateful deployments needs the `storageClass` name. Set the correct value as per your kubernetes cluster configuration. |
-        | rabbitmq.default_user | plane |  | Credentials are requried to access the hosted stateful deployment of `rabbitmq`.  Use this key to set the username for the stateful deployment. |
-        | rabbitmq.default_password | plane |  | Credentials are requried to access the hosted stateful deployment of `rabbitmq`.  Use this key to set the password for the stateful deployment. |
-        | rabbitmq.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
-        | rabbitmq.external_rabbitmq_url |  |  | Users can also decide to use the remote hosted service and link to Plane deployment. Ignoring all the above keys, set `rabbitmq.local_setup` to `false` and set this key with remote connection url. |
+        |---------|---------|----------|-------------|
+        | rabbitmq.local_setup | true | | Plane uses rabbitmq as message queuing system. This can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws mq or similar services). Set this to true when you choose to setup stateful deployment of rabbitmq. Mark it as false when using a remotely hosted service |
+        | rabbitmq.image | rabbitmq:3.13.6-management-alpine | | Using this key, user must provide the docker image name to setup the stateful deployment of rabbitmq. (must be set when `rabbitmq.local_setup=true`) |
+        | rabbitmq.pullPolicy | IfNotPresent | | Using this key, user can set the pull policy for the stateful deployment of rabbitmq. (must be set when `rabbitmq.local_setup=true`) |
+        | rabbitmq.servicePort | 5672 | | This key sets the default port number to be used while setting up stateful deployment of rabbitmq. |
+        | rabbitmq.managementPort | 15672 | | This key sets the default management port number to be used while setting up stateful deployment of rabbitmq. |
+        | rabbitmq.volumeSize | 100Mi | | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
+        | rabbitmq.storageClass | `<k8s-default-storage-class>` | | Creating the persitant volumes for the stateful deployments needs the storageClass name. Set the correct value as per your kubernetes cluster configuration. |
+        | rabbitmq.default_user | plane | | Credentials are requried to access the hosted stateful deployment of rabbitmq. Use this key to set the username for the stateful deployment. |
+        | rabbitmq.default_password | plane | | Credentials are requried to access the hosted stateful deployment of rabbitmq. Use this key to set the password for the stateful deployment. |
+        | rabbitmq.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+        | rabbitmq.external_rabbitmq_url | | | Users can also decide to use the remote hosted service and link to Plane deployment. Ignoring all the above keys, set rabbitmq.local_setup to false and set this key with remote connection url. |
+        | rabbitmq.nodeSelector | {} | | This key allows you to set the node selector for the stateful deployment of rabbitmq. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | rabbitmq.tolerations | [] | | This key allows you to set the tolerations for the stateful deployment of rabbitmq. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | rabbitmq.affinity | {} | | This key allows you to set the affinity rules for the stateful deployment of rabbitmq. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | rabbitmq.labels | {} | | This key allows you to set custom labels for the stateful deployment of rabbitmq. This is useful for organizing and selecting resources in your Kubernetes cluster. |
+        | rabbitmq.annotations | {} | | This key allows you to set custom annotations for the stateful deployment of rabbitmq. This is useful for adding metadata or configuration hints to your resources. |
 
         #### Doc Store (Minio/S3) Setup
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | minio.local_setup | true |  | Plane uses `minio` as the default file storage drive. This storage can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws S3 or similar services). Set this to  `true` when you choose to setup stateful deployment of `postgres`. Mark it as `false` when using a remotely hosted database |
-        | minio.image | minio/minio:latest |  | Using this key, user must provide the docker image name to setup the stateful deployment of `minio`. (must be set when `minio.local_setup=true`)|
-        | minio.image_mc | minio/mc:latest |  | Using this key, user must provide the docker image name to setup the job deployment of `minio client`. (must be set when `services.minio.local_setup=true`)|
-        | minio.pullPolicy | IfNotPresent |  | Using this key, user can set the pull policy for the stateful deployment of `minio`. (must be set when `minio.local_setup=true`)|
-        | minio.volumeSize | 5Gi |  | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
-        | minio.root_user | admin |  | Storage credentials are requried to access the hosted stateful deployment of `minio`.  Use this key to set the username for the stateful deployment. |
-        | minio.root_password | password |  | Storage credentials are requried to access the hosted stateful deployment of `minio`.  Use this key to set the password for the stateful deployment. |
-        | minio.env.minio_endpoint_ssl | false |  | (Optional) Env to enforce HTTPS when connecting to minio uploads bucket  |
-        | env.docstore_bucket | uploads | Yes | Storage bucket name is required as part of configuration. This is where files will be uploaded irrespective of if you are using `Minio` or external `S3` (or compatible) storage service |
+        |---------|---------|----------|-------------|
+        | minio.local_setup | true | | Plane uses minio as the default file storage drive. This storage can be hosted within kubernetes as part of helm chart deployment or can be used as hosted service remotely (e.g. aws S3 or similar services). Set this to true when you choose to setup stateful deployment of postgres. Mark it as false when using a remotely hosted database |
+        | minio.image | minio/minio:latest | | Using this key, user must provide the docker image name to setup the stateful deployment of minio. (must be set when `minio.local_setup=true`) |
+        | minio.image_mc | minio/mc:latest | | Using this key, user must provide the docker image name to setup the job deployment of minio client. (must be set when `minio.local_setup=true`) |
+        | minio.pullPolicy | IfNotPresent | | Using this key, user can set the pull policy for the stateful deployment of minio. (must be set when `minio.local_setup=true`) |
+        | minio.volumeSize | 5Gi | | While setting up the stateful deployment, while creating the persistant volume, volume allocation size need to be provided. This key helps you set the volume allocation size. Unit of this value must be in Mi (megabyte) or Gi (gigabyte) |
+        | minio.root_user | admin | | Storage credentials are requried to access the hosted stateful deployment of minio. Use this key to set the username for the stateful deployment. |
+        | minio.root_password | password | | Storage credentials are requried to access the hosted stateful deployment of minio. Use this key to set the password for the stateful deployment. |
+        | minio.env.minio_endpoint_ssl | false | | (Optional) Env to enforce HTTPS when connecting to minio uploads bucket |
+        | env.docstore_bucket | uploads | Yes | Storage bucket name is required as part of configuration. This is where files will be uploaded irrespective of if you are using Minio or external S3 (or compatible) storage service |
         | env.doc_upload_size_limit | 5242880 | Yes | Document Upload Size Limit (default to 5Mb) |
-        | env.aws_access_key |  |  | External `S3` (or compatible) storage service provides `access key` for the application to connect and do the necessary upload/download operations. To be provided when `minio.local_setup=false`  |
-        | env.aws_secret_access_key |  |  | External `S3` (or compatible) storage service provides `secret access key` for the application to connect and do the necessary upload/download operations. To be provided when `minio.local_setup=false`  |
-        | env.aws_region |  |  | External `S3` (or compatible) storage service providers creates any buckets in user selected region. This is also shared with the user as `region` for the application to connect and do the necessary upload/download operations. To be provided when `minio.local_setup=false`  |
-        | env.aws_s3_endpoint_url |  |  | External `S3` (or compatible) storage service providers shares a `endpoint_url` for the integration purpose for the application to connect and do the necessary upload/download operations. To be provided when `minio.local_setup=false`  |
-        | minio.storageClass | &lt;k8s-default-storage-class&gt; |  | Creating the persitant volumes for the stateful deployments needs the `storageClass` name. Set the correct value as per your kubernetes cluster configuration. |
-        | minio.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+        | env.aws_access_key | | | External S3 (or compatible) storage service provides access key for the application to connect and do the necessary upload/download operations. To be provided when `minio.local_setup=false` |
+        | env.aws_secret_access_key | | | External S3 (or compatible) storage service provides secret access key for the application to connect and do the necessary upload/download operations. To be provided when `minio.local_setup=false` |
+        | env.aws_region | | | External S3 (or compatible) storage service providers creates any buckets in user selected region. This is also shared with the user as region for the application to connect and do the necessary upload/download operations. To be provided when `minio.local_setup=false` |
+        | env.aws_s3_endpoint_url | | | External S3 (or compatible) storage service providers shares a endpoint_url for the integration purpose for the application to connect and do the necessary upload/download operations. To be provided when minio.`local_setup=false` |
+        | minio.storageClass | `<k8s-default-storage-class>` | | Creating the persitant volumes for the stateful deployments needs the storageClass name. Set the correct value as per your kubernetes cluster configuration. |
+        | minio.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+        | minio.nodeSelector | {} | | This key allows you to set the node selector for the stateful deployment of minio. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | minio.tolerations | [] | | This key allows you to set the tolerations for the stateful deployment of minio. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | minio.affinity | {} | | This key allows you to set the affinity rules for the stateful deployment of minio. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | minio.labels | {} | | This key allows you to set custom labels for the stateful deployment of minio. This is useful for organizing and selecting resources in your Kubernetes cluster. |
+        | minio.annotations | {} | | This key allows you to set custom annotations for the stateful deployment of minio. This is useful for adding metadata or configuration hints to your resources. |
 
         #### Web Deployment
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | web.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
-        | web.memoryLimit | 1000Mi |  | Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
-        | web.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-        | web.image| artifacts.plane.so/makeplane/plane-frontend |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
-        | web.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `web`. |  
-        | web.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+        |---------|---------|----------|-------------|
+        | web.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be `>=1` |
+        | web.memoryLimit | 1000Mi | | Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use. |
+        | web.cpuLimit | 500m | | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use. |
+        | web.memoryRequest | 50Mi | | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+        | web.cpuRequest | 50m | | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
+        | web.image | artifacts.plane.so/makeplane/plane-frontend | | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+        | web.pullPolicy | Always | | Using this key, user can set the pull policy for the deployment of web. |
+        | web.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+        | web.nodeSelector | {} | | This key allows you to set the node selector for the deployment of web. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | web.tolerations | [] | | This key allows you to set the tolerations for the deployment of web. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | web.affinity | {} | | This key allows you to set the affinity rules for the deployment of web. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | web.labels | {} | | Custom labels to add to the web deployment |
+        | web.annotations | {} | | Custom annotations to add to the web deployment |
 
         #### Space Deployment
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | space.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
-        | space.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
-        | space.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-        | space.image| artifacts.plane.so/makeplane/plane-space|  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
-        | space.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `space`. |
-        | space.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+        |---------|---------|----------|-------------|
+        | space.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be `>=1` |
+        | space.memoryLimit | 1000Mi | | Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use. |
+        | space.cpuLimit | 500m | | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use. |
+        | space.memoryRequest | 50Mi | | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+        | space.cpuRequest | 50m | | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
+        | space.image | artifacts.plane.so/makeplane/plane-space | | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+        | space.pullPolicy | Always | | Using this key, user can set the pull policy for the deployment of space. |
+        | space.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+        | space.nodeSelector | {} | | This key allows you to set the node selector for the deployment of space. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | space.tolerations | [] | | This key allows you to set the tolerations for the deployment of space. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | space.affinity | {} | | This key allows you to set the affinity rules for the deployment of space. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | space.labels | {} | | Custom labels to add to the space deployment |
+        | space.annotations | {} | | Custom annotations to add to the space deployment |
 
         #### Admin Deployment
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | admin.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
-        | admin.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
-        | admin.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-        | admin.image| artifacts.plane.so/makeplane/plane-admin |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
-        | admin.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `admin`. |
-        | admin.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+        |---------|---------|----------|-------------|
+        | admin.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be `>=1` |
+        | admin.memoryLimit | 1000Mi | | Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use. |
+        | admin.cpuLimit | 500m | | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use. |
+        | admin.memoryRequest | 50Mi | | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+        | admin.cpuRequest | 50m | | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
+        | admin.image | artifacts.plane.so/makeplane/plane-admin | | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+        | admin.pullPolicy | Always | | Using this key, user can set the pull policy for the deployment of admin. |
+        | admin.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+        | admin.nodeSelector | {} | | This key allows you to set the node selector for the deployment of admin. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | admin.tolerations | [] | | This key allows you to set the tolerations for the deployment of admin. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | admin.affinity | {} | | This key allows you to set the affinity rules for the deployment of admin. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | admin.labels | {} | | Custom labels to add to the admin deployment |
+        | admin.annotations | {} | | Custom annotations to add to the admin deployment |
 
         #### Live Service Deployment
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | live.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
-        | live.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
-        | live.cpuLimit | 500m |  |  Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-        | live.image| artifacts.plane.so/makeplane/plane-live |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
-        | live.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `live`. |
-        | env.live_sentry_dsn |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry provided DSN for this integration.|
-        | env.live_sentry_environment |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration.|
-        | env.live_sentry_traces_sample_rate |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry trace sample rate (as configured in Sentry) for this integration.|
-        | live.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
-
+        |---------|---------|----------|-------------|
+        | live.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be `>=1` |
+        | live.memoryLimit | 1000Mi | | Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use. |
+        | live.cpuLimit | 500m | | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use. |
+        | live.memoryRequest | 50Mi | | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+        | live.cpuRequest | 50m | | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
+        | live.image | artifacts.plane.so/makeplane/plane-live | | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+        | live.pullPolicy | Always | | Using this key, user can set the pull policy for the deployment of live. |
+        | live.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+        | live.nodeSelector | {} | | This key allows you to set the node selector for the deployment of live. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | live.tolerations | [] | | This key allows you to set the tolerations for the deployment of live. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | live.affinity | {} | | This key allows you to set the affinity rules for the deployment of live. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | live_server_secret_key | htbqvBJAgpm9bzvf3r4urJer0ENReatceh | Yes | This key sets the secret key for the live server. This is required for secure communication and authentication in the live server component. |
+        | live.labels | {} | | Custom labels to add to the live deployment |
+        | live.annotations | {} | | Custom annotations to add to the live deployment |
 
         #### API Deployment
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | api.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be >=1 |
-        | api.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
-        | api.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-        | api.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
-        | api.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `api`. |
-        | env.sentry_dsn |  |  | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry provided DSN for this integration.|
-        | env.sentry_environment |  |  | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration.|
-        | env.api_key_rate_limit | 60/minute |  | (optional) User can set the maximum number of requests the API can handle in a given time frame.|
-        | api.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+        |---------|---------|----------|-------------|
+        | api.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be `>=1` |
+        | api.memoryLimit | 1000Mi | | Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use. |
+        | api.cpuLimit | 500m | | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use. |
+        | api.memoryRequest | 50Mi | | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+        | api.cpuRequest | 50m | | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
+        | api.image | artifacts.plane.so/makeplane/plane-backend | | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+        | api.pullPolicy | Always | | Using this key, user can set the pull policy for the deployment of api. |
+        | env.sentry_dsn | | | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry provided DSN for this integration. |
+        | env.sentry_environment | | | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration. |
+        | env.api_key_rate_limit | 60/minute | | (optional) User can set the maximum number of requests the API can handle in a given time frame. |
+        | api.assign_cluster_ip | false | | Set it to true if you want to assign ClusterIP to the service |
+        | api.nodeSelector | {} | | This key allows you to set the node selector for the deployment of api. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | api.tolerations | [] | | This key allows you to set the tolerations for the deployment of api. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | api.affinity | {} | | This key allows you to set the affinity rules for the deployment of api. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | api.labels | {} | | Custom labels to add to the API deployment |
+        | api.annotations | {} | | Custom annotations to add to the API deployment |
 
         #### Worker Deployment
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | worker.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you set up the number of replicas you want to run for this deployment. It must be >=1 |
-        | worker.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use the maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
-        | worker.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use the maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-        | worker.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+        |---------|---------|----------|-------------|
+        | worker.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be `>=1` |
+        | worker.memoryLimit | 1000Mi | | Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use. |
+        | worker.cpuLimit | 500m | | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use. |
+        | worker.memoryRequest | 50Mi | | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+        | worker.cpuRequest | 50m | | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
+        | worker.image | artifacts.plane.so/makeplane/plane-backend | | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+        | worker.nodeSelector | {} | | This key allows you to set the node selector for the deployment of worker. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | worker.tolerations | [] | | This key allows you to set the tolerations for the deployment of worker. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | worker.affinity | {} | | This key allows you to set the affinity rules for the deployment of worker. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | worker.labels | {} | | Custom labels to add to the worker deployment |
+        | worker.annotations | {} | | Custom annotations to add to the worker deployment |
 
-        #### Beat-Worker deployment
-
-        | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | beatworker.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you set up the number of replicas you want to run for this deployment. It must be >=1 |
-        | beatworker.memoryLimit | 1000Mi |  |  Every deployment in kubernetes can be set to use the maximum memory they are allowed to use. This key sets the memory limit for this deployment to use.|
-        | beatworker.cpuLimit | 500m |  | Every deployment in kubernetes can be set to use the maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use.|
-        | beatworker.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
-
-        #### External Secrets Config
-
-        To configure the external secrets for your application, you need to define specific environment variables for each secret category. Below is a list of the required secrets and their respective environment variables. See [External secrets](/self-hosting/govern/external-secrets) for setup details. 
-
-        | Secret Name | Env Var Name | Required | Description | Example Value |
-        |--- |:---|:---|:---|:---|
-        | rabbitmq_existingSecret     | `RABBITMQ_DEFAULT_USER`  | Required if `rabbitmq.local_setup=true` | The default RabbitMQ user                    | `plane`      |
-        |                      | `RABBITMQ_DEFAULT_PASS`  | Required if `rabbitmq.local_setup=true` | The default RabbitMQ password                | `plane`      |
-        | pgdb_existingSecret         | `POSTGRES_PASSWORD`      | Required if `postgres.local_setup=true` | Password for PostgreSQL database             | `plane`   |
-        |                      | `POSTGRES_DB`            | Required if `postgres.local_setup=true` | Name of the PostgreSQL database              | `plane`      |
-        |                      | `POSTGRES_USER`          | Required if `postgres.local_setup=true` | PostgreSQL user                              | `plane`       |
-        |  doc_store_existingSecret                 | `USE_MINIO`              | Yes | Flag to enable MinIO as the storage backend  | `1`         |
-        |                      | `MINIO_ROOT_USER`        | Yes | MinIO root user                              | `admin`    |
-        |     | `MINIO_ROOT_PASSWORD`    | Yes | MinIO root password                          | `password`    |
-        |                      | `AWS_ACCESS_KEY_ID`      | Yes | AWS Access Key ID                            | `your_aws_key`       |
-        |                      | `AWS_SECRET_ACCESS_KEY`  | Yes | AWS Secret Access Key                        | `your_aws_secret`    |
-        |                      | `AWS_S3_BUCKET_NAME`     | Yes | AWS S3 Bucket Name                           | `your_bucket_name`   |
-        |                      | `AWS_S3_ENDPOINT_URL`    | Yes | Endpoint URL for AWS S3 or MinIO             | `http://plane-minio.plane-ns.svc.cluster.local:9000`  |
-        |                      | `AWS_REGION`             | Optional | AWS region where your S3 bucket is located   | `your_aws_region`    |
-        |                      | `FILE_SIZE_LIMIT`        | Yes | Limit for file uploads in your system        | `5MB`               |
-        | app_env_existingSecret      | `SECRET_KEY`             | Yes | Random secret key                            | `60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5`  |
-        |                      | `REDIS_URL`              | Yes | Redis URL                                    | `redis://plane-redis.plane-ns.svc.cluster.local:6379/`  |
-        |                      | `DATABASE_URL`           | Yes | PostgreSQL connection URL                    | **k8s service example**: `postgresql://plane:plane@plane-pgdb.plane-ns.svc.cluster.local:5432/plane` <br/> <br/>**external service example**: `postgresql://username:password@your-db-host:5432/plane` |
-        |                      | `AMQP_URL`               | Yes | RabbitMQ connection URL                      | **k8s service example**: `amqp://plane:plane@plane-rabbitmq.plane-ns.svc.cluster.local:5672/`  <br/> <br/> **external service example**: `amqp://username:password@your-rabbitmq-host:5672/` |
-
-        #### Ingress and SSL Setup
+        #### Beat-Worker Deployment
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | ingress.enabled | true |  | Ingress setup in kubernetes is a common practice to expose application to the intended audience.  Set it to `false` if you are using external ingress providers like `Cloudflare` |
-        | ingress.appHost | plane.example.com | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
-        | ingress.minioHost |  |  | Based on above configuration, if you want to expose the `minio` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface. |
-        | ingress.rabbitmqHost |  |  | Based on above configuration, if you want to expose the `rabbitmq` web console to set of users, use this key to set the `host` mapping or leave it as `EMPTY` to not expose interface. |
-        | ingress.ingressClass | nginx | Yes | Kubernetes cluster setup comes with various options of `ingressClass`. Based on your setup, set this value to the right one (eg. nginx, traefik, etc). Leave it to default in case you are using external ingress provider.|
-        | ingress.ingress_annotations | `{ "nginx.ingress.kubernetes.io/proxy-body-size": "5m" }` |  | Ingress controllers comes with various configuration options which can be passed as annotations. Setting this value lets you change the default value to user required. |
-        | ssl.createIssuer | false |  | Kubernets cluster setup supports creating `issuer` type resource. After deployment, this is step towards creating secure access to the ingress url. Issuer is required for you generate SSL certifiate. Kubernetes can be configured to use any of the certificate authority to generate SSL (depending on CertManager configuration). Set it to `true` to create the issuer. Applicable only when `ingress.enabled=true`|
-        | ssl.issuer | http |  | CertManager configuration allows user to create issuers using `http` or any of the other DNS Providers like `cloudflare`, `digitalocean`, etc. As of now Plane supports `http`, `cloudflare`, `digitalocean`|
-        | ssl.token |  |  | To create issuers using DNS challenge, set the issuer api token of dns provider like cloudflare` or `digitalocean`(not required for http) |
-        | ssl.server | `<https://acme-v02.api.letsencrypt.org/directory>` |  | Issuer creation configuration need the certificate generation authority server url. Default URL is the `Let's Encrypt` server|
-        | ssl.email | `<plane@example.com>` |  | Certificate generation authority needs a valid email id before generating certificate. Required when `ssl.createIssuer=true`  |
-        | ssl.generateCerts | false |  | After creating the issuers, user can still not create the certificate untill sure of configuration. Setting this to `true` will try to generate SSL certificate and associate with ingress. Applicable only when `ingress.enabled=true` and `ssl.createIssuer=true` |
-        | ssl.tls_secret_name |  |  | If you have a custom TLS secret name, set this to the name of the secret. Applicable only when `ingress.enabled=true` and `ssl.createIssuer=false` |
+        |---------|---------|----------|-------------|
+        | beatworker.replicas | 1 | Yes | Kubernetes helps you with scaling up/down the deployments. You can run 1 or more pods for each deployment. This key helps you setting up number of replicas you want to run for this deployment. It must be `>=1` |
+        | beatworker.memoryLimit | 1000Mi | | Every deployment in kubernetes can be set to use maximum memory they are allowed to use. This key sets the memory limit for this deployment to use. |
+        | beatworker.cpuLimit | 500m | | Every deployment in kubernetes can be set to use maximum cpu they are allowed to use. This key sets the cpu limit for this deployment to use. |
+        | beatworker.memoryRequest | 50Mi | | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use. |
+        | beatworker.cpuRequest | 50m | | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use. |
+        | beatworker.image | artifacts.plane.so/makeplane/plane-backend | | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+        | beatworker.nodeSelector | {} | | This key allows you to set the node selector for the deployment of beatworker. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+        | beatworker.tolerations | [] | | This key allows you to set the tolerations for the deployment of beatworker. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+        | beatworker.affinity | {} | | This key allows you to set the affinity rules for the deployment of beatworker. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
+        | beatworker.labels | {} | | Custom labels to add to the beat-worker deployment |
+        | beatworker.annotations | {} | | Custom annotations to add to the beat-worker deployment |
 
         #### Common Environment Settings
 
         | Setting | Default | Required | Description |
-        |---|:---:|:---:|---|
-        | env.secret_key | 60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5 | Yes | This must be a random string that is used for hashing/encrypting the sensitive data within the application. Once set, changing this might impact the already hashed/encrypted data|
+        |---------|---------|----------|-------------|
+        | env.secret_key | 60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5 | Yes | This must a random string which is used for hashing/encrypting the sensitive data within the application. Once set, changing this might impact the already hashed/encrypted data |
+        | env.default_cluster_domain | cluster.local | Yes | Set this value as configured in your kubernetes cluster. cluster.local is usally the default in most cases. |
 </Accordion>


### PR DESCRIPTION
…#158)

### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Airgapped edition docs and updates Kubernetes install/config to v1.15.0 with airgapped options, new optional services, and expanded per‑service configuration and scheduling controls.
> 
> - **Docs — Editions**
>   - Add new **Airgapped** self‑hosted edition with capabilities and positioning.
>   - Update references to editions and version‑management to include Airgapped.
> - **Docs — Kubernetes (Commercial)**
>   - Bump `PLANE_VERSION`/`planeVersion` to `v1.15.0`.
>   - Add Airgapped configuration (`airgapped.enabled`, custom S3 CA secret options).
>   - Expand per‑service settings: resource requests, image `pullPolicy`, scheduling controls (`nodeSelector`, `tolerations`, `affinity`), and metadata (`labels`, `annotations`).
>   - Add optional services: `email_service`, `outbox_poller`, `automation_consumer`, and `iframely`; plus new envs (e.g., `env.live_server_secret_key`, `env.external_iframely_url`).
>   - Update External Secrets and Ingress/SSL tables; add global `extraEnv` support.
> - **Docs — Kubernetes (Community Accordion)**
>   - Standardize/expand configuration tables, defaults (e.g., `planeVersion v1.1.0`), and add scheduling/metadata options across components; add `env.default_cluster_domain`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99b8abe309afde0fcd9eda16f228174a9e13751f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->