### PR TITLE
Update Kubernetes configuration to version v1.16.0

### DIFF
--- a/self-hosting/methods/kubernetes.mdx
+++ b/self-hosting/methods/kubernetes.mdx
@@ -26,7 +26,7 @@ Ensure you use use the latest Helm chart version.
     1. Open terminal or any other command-line app that has access to Kubernetes tools on your local system.
     2. Set the following environment variables:
         ```bash
-        PLANE_VERSION=v1.15.0
+        PLANE_VERSION=v1.16.0
         ```
         ```bash
         DOMAIN_NAME=<subdomain.domain.tld or domain.tld>
@@ -83,7 +83,7 @@ Ensure you use use the latest Helm chart version.
             ```
 
             Make sure you set the required environment variables listed below:
-            - `planeVersion: v1.15.0`
+            - `planeVersion: v1.16.0`
             - `license.licenseDomain: <The domain you have specified to host Plane>`
             - `license.licenseServer: https://prime.plane.so`
             - `ingress.enabled: <true | false>`
@@ -113,7 +113,7 @@ If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so
 
     | Setting | Default | Required | Description |
     |---|:---:|:---:|---|
-    | planeVersion | v1.15.0	 | Yes |  Specifies the version of Plane to be deployed. Copy this from `prime.plane.so.` |
+    | planeVersion | v1.16.0	 | Yes |  Specifies the version of Plane to be deployed. Copy this from `prime.plane.so.` |
     | license.licenseDomain | 'plane.example.com' | Yes | The fully-qualified domain name (FQDN) in the format `sudomain.domain.tld` or `domain.tld` that the license is bound to. It is also attached to your `ingress` host to access Plane. |
 
     #### Airgapped settings


### PR DESCRIPTION
<!-- Provide a detailed description of the changes in this PR -->
This pull request updates the documentation for the Kubernetes self-hosting method to reference the latest Helm chart and Plane version. The main change is updating all references of the `planeVersion` from `v1.15.0` to `v1.16.0` to ensure users install the most recent release.

Helm chart version update:

* Updated environment variable examples, configuration instructions, and documentation tables to use `planeVersion: v1.16.0` instead of `v1.15.0` in `self-hosting/methods/kubernetes.mdx`. 

