### PR TITLE
Update master branch with changes

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -51,7 +51,7 @@
       "url": "api-reference"
     },
     {
-      "name": "Dev Tools",
+      "name": "Build and extend",
       "url": "dev-tools"
     }
   ],
@@ -67,12 +67,16 @@
     {
       "group": "Install",
       "pages": [
-        "self-hosting/methods/docker-compose",
-        "self-hosting/methods/docker-aio",
-        "self-hosting/methods/docker-swarm",
+        {
+          "group": "Docker",
+          "pages": [
+               "self-hosting/methods/docker-compose",
+               "self-hosting/methods/docker-aio",
+               "self-hosting/methods/docker-swarm"
+            ]
+        },
         "self-hosting/methods/kubernetes",
-        "self-hosting/methods/coolify",
-        "self-hosting/methods/portainer",
+        "self-hosting/methods/podman-quadlets",
         {
           "group": "Airgapped Edition",
           "pages": [
@@ -80,7 +84,13 @@
               "self-hosting/methods/airgapped-edition-kubernetes"
             ]
         },
-        "self-hosting/methods/podman-quadlets"
+        {
+          "group": "Managed platforms",
+          "pages": [
+               "self-hosting/methods/coolify",
+               "self-hosting/methods/portainer"
+            ]
+        }
       ]
     },
     {

--- a/self-hosting/methods/coolify.mdx
+++ b/self-hosting/methods/coolify.mdx
@@ -43,5 +43,6 @@ This guide shows you the steps to deploy a self-hosted instance of Plane using C
    - `AMQP_URL` – Connection string for your external RabbitMQ server.
 
 8. Deploy to launch your Plane instance.
+    Once the deployment is complete, your Plane instance should be accessible on the configured domain.
 
-Once the deployment is complete, your Plane instance should be accessible on the configured domain.
+9. If you've purchased a paid plan, [activate your license key](https://docs.plane.so/workspaces-and-users/manage-licenses#activate-license) to unlock premium features.

--- a/self-hosting/methods/docker-aio.mdx
+++ b/self-hosting/methods/docker-aio.mdx
@@ -94,7 +94,9 @@ The following ports are exposed:
     artifacts.plane.so/makeplane/plane-aio-commercial:stable
     ```
 
-2. Once it's running, you can access the Plane application on the domain you provided during the deployment.
+3. Once it's running, you can access the Plane application on the domain you provided during the deployment.
+
+4. If you've purchased a paid plan, [activate your license key](https://docs.plane.so/workspaces-and-users/manage-licenses#activate-license) to unlock premium features.
 
 ## Volume mounts
 

--- a/self-hosting/methods/docker-compose.mdx
+++ b/self-hosting/methods/docker-compose.mdx
@@ -1,5 +1,5 @@
 ---
-title: Docker
+title: Docker Compose
 ---
 
 This guide shows you the steps to deploy a self-hosted instance of Plane using Docker.
@@ -40,10 +40,8 @@ Ensure you're using the **latest version of Docker Compose**. Check your Docker 
       When self-hosting Plane for production use, it is strongly recommended to configure [external database and storage](/self-hosting/govern/database-and-storage). This ensures that your data remains secure and accessible even if the local machine crashes or encounters hardware issues. Relying solely on local storage for these components increases the risk of data loss and service disruption.
       </Warning>
    6. The installation will take a few minutes to complete and you will see the message **Plane has successfully installed**. You can access the Plane application on the domain you provided during the installation. 
-   
-<Tip>
-If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so/workspaces-and-users/upgrade-plan).
-</Tip>
+   7. If you've purchased a paid plan, [activate your license key](https://docs.plane.so/workspaces-and-users/manage-licenses#activate-license) to unlock premium features.
+
 
 <Accordion title="Install Community Edition ">
   The Commercial edition comes with a free plan and the flexibility to upgrade to a paid plan at any point. If you still want to install the Community edition, follow the steps below:

--- a/self-hosting/methods/docker-swarm.mdx
+++ b/self-hosting/methods/docker-swarm.mdx
@@ -56,4 +56,6 @@ This guide shows you the steps to deploy a self-hosted instance of the Plane Com
     docker stack deploy -c <path-to swarm-compose.yml> plane
     ```
 
-That's it! This will deploy Plane as a Swarm stack, and your instance should be accessible on your configured domain.
+    That's it! This will deploy Plane as a Swarm stack, and your instance should be accessible on your configured domain.
+
+5. If you've purchased a paid plan, [activate your license key](https://docs.plane.so/workspaces-and-users/manage-licenses#activate-license) to unlock premium features.

--- a/self-hosting/methods/kubernetes.mdx
+++ b/self-hosting/methods/kubernetes.mdx
@@ -44,29 +44,29 @@ Ensure you use use the latest Helm chart version.
 
     4. Use one of the following ways to deploy Plane:
         - **Quick setup**:  
-        This is the fastest way to deploy Plane with the default settings. This will create stateful deployments for Postgres, Redis/Valkey, and Minio with a persistent volume claim using the `longhorn` storage class. This also sets up the Ingress routes for you using `nginx` ingress class. To customize these settings, see the [Custom ingress routes](#custom-ingress-routes).
+            This is the fastest way to deploy Plane with the default settings. This will create stateful deployments for Postgres, Redis/Valkey, and Minio with a persistent volume claim using the `longhorn` storage class. This also sets up the Ingress routes for you using `nginx` ingress class. To customize these settings, see the [Custom ingress routes](#custom-ingress-routes).
 
-        Run the following command to deploy Plane:
+            Run the following command to deploy Plane:
 
-            ```bash
-                helm install plane-app plane/plane-enterprise \
-                    --create-namespace \
-                    --namespace plane \
-                    --set license.licenseDomain=${DOMAIN_NAME} \
-                    --set license.licenseServer=https://prime.plane.so \
-                    --set planeVersion=${PLANE_VERSION} \
-                    --set ingress.enabled=true \
-                    --set ingress.ingressClass=nginx \
-                    --set env.storageClass=longhorn \
-                    --timeout 10m \
-                    --wait \
-                    --wait-for-jobs
-            ```
+                ```bash
+                    helm install plane-app plane/plane-enterprise \
+                        --create-namespace \
+                        --namespace plane \
+                        --set license.licenseDomain=${DOMAIN_NAME} \
+                        --set license.licenseServer=https://prime.plane.so \
+                        --set planeVersion=${PLANE_VERSION} \
+                        --set ingress.enabled=true \
+                        --set ingress.ingressClass=nginx \
+                        --set env.storageClass=longhorn \
+                        --timeout 10m \
+                        --wait \
+                        --wait-for-jobs
+                ```
 
-            <Note>
-            This is the minimum required to set up Plane Commercial edition. You can change the default namespace from `plane`, the default app name from `plane-app`, the default storage class from `longhorn`, and the default ingress class from `nginx` to whatever you would like to.<br/> <br/>
-            You can also pass other settings referring to the **Configuration Settings** toggle section below.
-            </Note>
+                <Note>
+                This is the minimum required to set up Plane Commercial edition. You can change the default namespace from `plane`, the default app name from `plane-app`, the default storage class from `longhorn`, and the default ingress class from `nginx` to whatever you would like to.<br/> <br/>
+                You can also pass other settings referring to the **Configuration Settings** toggle section below.
+                </Note>
 
         - **Advanced setup**: 
             <Warning>
@@ -77,20 +77,20 @@ Ensure you use use the latest Helm chart version.
             
             1. Run the script below to download the `values.yaml` file and and edit using any editor like Vim or Nano. 
 
-            ```bash
-            helm  show values plane/plane-enterprise > values.yaml
-            vi values.yaml
-            ```
+                ```bash
+                helm  show values plane/plane-enterprise > values.yaml
+                vi values.yaml
+                ```
 
-            Make sure you set the required environment variables listed below:
-            - `planeVersion: v1.16.0`
-            - `license.licenseDomain: <The domain you have specified to host Plane>`
-            - `license.licenseServer: https://prime.plane.so`
-            - `ingress.enabled: <true | false>`
-            - `ingress.ingressClass: <nginx or any other ingress class configured in your cluster>`
-            - `env.storageClass: <longhorn or any other storage class configured in your cluster>`
+                Make sure you set the required environment variables listed below:
+                - `planeVersion: v1.16.0`
+                - `license.licenseDomain: <The domain you have specified to host Plane>`
+                - `license.licenseServer: https://prime.plane.so`
+                - `ingress.enabled: <true | false>`
+                - `ingress.ingressClass: <nginx or any other ingress class configured in your cluster>`
+                - `env.storageClass: <longhorn or any other storage class configured in your cluster>`
 
-            See the **Configuration settings** toggle section for more details.
+                See the **Configuration settings** toggle section for more details.
 
             2. After saving the `values.yaml` file, run the following command to deploy Plane:
 
@@ -103,9 +103,7 @@ Ensure you use use the latest Helm chart version.
                     --wait \
                     --wait-for-jobs 
             ```
-<Tip>
-If you want to upgrade to a paid plan, see [Plan upgrades](https://docs.plane.so/workspaces-and-users/upgrade-plan).
-</Tip>
+    5. If you've purchased a paid plan, [activate your license key](https://docs.plane.so/workspaces-and-users/manage-licenses#activate-license) to unlock premium features.
 
 ### Configuration settings
 

--- a/self-hosting/methods/podman-quadlets.mdx
+++ b/self-hosting/methods/podman-quadlets.mdx
@@ -95,7 +95,9 @@ Note that you should run these commands without `sudo`.
     systemctl --user start {web,space,admin,live,proxy}.service
     ```
 
-The startup sequence is important: network first, then dependencies, followed by backend services, and finally frontend services.
+    The startup sequence is important: network first, then dependencies, followed by backend services, and finally frontend services.
+
+6. If you've purchased a paid plan, [activate your license key](https://docs.plane.so/workspaces-and-users/manage-licenses#activate-license) to unlock premium features.
 
 ### Verify service status
 Check that all services are running correctly:

--- a/self-hosting/methods/portainer.mdx
+++ b/self-hosting/methods/portainer.mdx
@@ -52,5 +52,6 @@ This guide shows you the steps to deploy a self-hosted instance of Plane using P
    - `AMQP_URL` – Connection string for your external RabbitMQ server.
 
 7. Click **Deploy the stack**.
+    That's it! Once the deployment is complete, Plane should be up and running on your configured domain.
 
-That's it! Once the deployment is complete, Plane should be up and running on your configured domain.
+8. If you've purchased a paid plan, [activate your license key](https://docs.plane.so/workspaces-and-users/manage-licenses#activate-license) to unlock premium features.


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds license activation steps across install guides, updates Kubernetes docs to v1.16.0, and reorganizes navigation (Docker grouping, Managed platforms), including renaming the Docker Compose page and a top-level tab.
> 
> - **Docs navigation**
>   - Rename top tab to `Build and extend` in `mint.json`.
>   - Reorganize `Install` section: add `Docker` group (compose/aio/swarm), add `Managed platforms` group (coolify/portainer), include `podman-quadlets` entry.
> - **Kubernetes guide (`self-hosting/methods/kubernetes.mdx`)**
>   - Update `PLANE_VERSION` references and config table from `v1.15.0` to `v1.16.0`.
>   - Add step to activate license after deployment.
> - **Install guides updates**
>   - Add post-deploy license activation step to: `docker-aio.mdx`, `docker-compose.mdx`, `docker-swarm.mdx`, `podman-quadlets.mdx`, `portainer.mdx`, `coolify.mdx`.
>   - Minor wording/ordering tweaks; retitle `Docker` page to `Docker Compose`; add confirmation lines where applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81399821e2f804d99986150f14b6123f0ed90867. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->