### PR TITLE
feat: add options field docs in create property API

### DIFF
--- a/api-reference/issue-types/properties/add-property.mdx
+++ b/api-reference/issue-types/properties/add-property.mdx
@@ -33,3 +33,15 @@ Default value(s) for the property.
 <ParamField body="is_required" type="boolean">Whether this property is required when creating work items.</ParamField>
 <ParamField body="is_active" type="boolean">Whether this property is currently active.</ParamField>
 <ParamField body="is_multi" type="boolean">Whether this property allows multiple values.</ParamField>
+<ParamField body="options" type="object[]">
+Array of option objects for OPTION type properties. This field can be used while creating a property with type OPTION to set options on the custom property during creation itself. Each option object can contain:
+- `name` (string): Name of the option
+- `description` (string): Description of the option
+- `is_active` (boolean): Whether the option is active
+- `sort_order` (number): Sort order for the option
+- `parent` (string): Parent option ID for hierarchical options
+- `is_default` (boolean): Whether this is the default option
+- `logo_props` (object): Logo properties for the option
+
+To add or update options on an OPTION property after creation, you can use the APIs from [`issue-types/options/add-dropdown-options`](/api-reference/issue-types/options/add-dropdown-options).
+</ParamField>

--- a/api-reference/issue-types/values/add-property-values.mdx
+++ b/api-reference/issue-types/values/add-property-values.mdx
@@ -22,6 +22,20 @@ The unique identifier for the work item.
 
 ## Body parameters
 
-<ParamField body="values" type="object[]" required> 
-  <ParamField body="value" type="string" required></ParamField>
+<ParamField body="value" type="string | boolean | number | string[]" required>
+The value type depends on the property type:
+- TEXT/URL/EMAIL/FILE: string
+- DATETIME: string (YYYY-MM-DD or YYYY-MM-DD HH:MM:SS)
+- DECIMAL: number (int or float)
+- BOOLEAN: boolean (true/false)
+- OPTION/RELATION (single): string (UUID)
+- OPTION/RELATION (multi, when is_multi=True): list of strings (UUIDs) or single string
+
+For multi-value properties (is_multi=True):
+- Accept either a single UUID string or a list of UUID strings
+- Multiple records are created
+- Response will be a list of values
+
+For single-value properties:
+- Only one value is allowed per work item/property combination
 </ParamField>


### PR DESCRIPTION
### Description
- Create property API will now take `options` in the payload to create options in one call for OPTION type
- Update type for setting custom property values with latest api changes

### Type of Change
- [X] Feature (non-breaking change which adds functionality)
- [X] Improvement (change that would cause existing functionality to not work as expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated add-property API documentation with new "options" parameter for OPTION-type properties.
  * Refined add-property-values API parameter structure to support multiple value types (string, boolean, number, arrays).
  * Enhanced guidance on multi-value property handling and per-property-type behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->