### PR TITLE
Change custom domain on Commercial edition

### DIFF
--- a/self-hosting/govern/custom-domain.mdx
+++ b/self-hosting/govern/custom-domain.mdx
@@ -3,9 +3,90 @@ title: Custom domain
 sidebarTitle: Custom domain
 description: Host your Plane instance in your custom domain. 
 ---
+During Plane Commercial Edition installation, you configure a domain for your instance. If you need to change that domain later, whether you're moving to a production domain, switching to a different hostname, or updating your DNS configuration, this guide walks you through the process.
+
 <Note>
-With the Commercial Edition, you can set up a custom domain right during installation. If you ever need to change the domain later, just contact our support team for assistance until we ship out a feature that lets you handle domain changes yourself.
+**Prime CLI is for Docker installations only.** These commands only work on Plane instances originally installed using `prime-cli`.
+
+If you're running Kubernetes or another deployment method, the environment variable names are the same, but the configuration method differs based on your setup.
 </Note>
+
+<Warning>
+**Plan for downtime**  
+Changing domains requires restarting Plane services. Your instance will be unavailable for a few minutes during the restart. Plan accordingly or notify your users.
+</Warning>
+
+## Check current domain configuration
+
+First, see which environment variables currently reference your old domain. This helps you identify exactly what needs updating.
+
+```bash
+cat /opt/plane/plane.env | grep <old_domain>
+```
+
+**Example output:**
+```env
+DOMAIN_NAME=localhost
+SITE_ADDRESS=http://localhost
+WEB_URL=http://localhost
+CORS_ALLOWED_ORIGINS=http://localhost,https://localhost
+```
+
+This shows you all the variables that contain your current domain. You'll update each of these in the next step.
+
+## Update domain in environment file
+
+1. Open the Plane environment configuration file:
+    ```bash
+    vim /opt/plane/plane.env
+    ```
+
+2. Find and update these environment variables with your new domain:
+
+    - **DOMAIN_NAME**
+
+    Set this to your bare domain name without protocol:
+    ```env
+    DOMAIN_NAME=plane.company.com
+    ```
+
+    Don't include `http://` or `https://` here, just the hostname.
+
+    - **SITE_ADDRESS**
+
+    Set this to your full domain URL:
+    ```env
+    SITE_ADDRESS=https://plane.company.com
+    ```
+
+    Include the protocol (`https://` for SSL, `http://` if you haven't set up SSL yet).
+
+    - **WEB_URL**
+
+    This should match your SITE_ADDRESS:
+    ```env
+    WEB_URL=https://plane.company.com
+    ```
+
+    Again, include the full protocol.
+
+    **CORS_ALLOWED_ORIGINS**
+
+    List all domains that should be allowed to make cross-origin requests to your Plane instance. This typically includes both HTTP and HTTPS versions of your domain:
+    ```env
+    CORS_ALLOWED_ORIGINS=https://plane.company.com,http://plane.company.com
+    ```
+
+    Separate multiple entries with commas, no spaces. If you have multiple domains or subdomains that need access, add them all here.
+
+## Restart Plane services
+
+Apply your configuration changes by restarting Plane:
+    ```bash
+    sudo prime-cli restart
+    ```
+
+This process typically takes a few minutes. You'll see output indicating the status of each service as it restarts.
 
 <Accordion title="Community Edition">
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a clear workflow to change the domain for Commercial Edition installations and clarifies environment and deployment specifics.
> 
> - Adds step-by-step guide: check `plane.env`, update `DOMAIN_NAME`, `SITE_ADDRESS`, `WEB_URL`, `CORS_ALLOWED_ORIGINS`, then restart services via `prime-cli restart`.
> - Warns about brief downtime during service restarts and notes that Prime CLI applies only to Docker installs; other deployments (e.g., Kubernetes) must configure equivalently.
> - Retains Community Edition guidance: update `.env`, configure DNS A record (public IP) or reverse proxy (internal IP).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2dc183ad55a63cb89cbdf20c1ad9d0f70b9a9b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->