### PR TITLE
feat(vercel): add Vary: accept so CDN serves markdown to agents

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
         {
           "key": "Link",
           "value": "</llms.txt>; rel=\"describedby\"; type=\"text/plain\", </api-reference/introduction>; rel=\"service-doc\"; type=\"text/html\", </sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\""
+        },
+        {
+          "key": "Vary",
+          "value": "accept"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Adds `Vary: accept` to the global response headers in `vercel.json`
- Fixes the Accept-based markdown negotiation shipped in #263, which was being masked by CDN caching
- Unblocks agents requesting `Accept: text/markdown` from receiving `content-type: text/markdown`

## Why

PR #263 wired up `buildEnd` to copy `.md` into `dist/` and added a rewrite rule that routes `Accept: text/markdown` to `/:path*.md`. In practice, the rewrite only wins on a cold cache — once HTML is cached for a path, Vercel's CDN serves that HTML for all subsequent requests regardless of Accept header, because responses don't advertise that they vary on it.

Advertising `Vary: accept` lets the CDN split the cache so HTML and markdown coexist as separate entries. Cloudflare's [Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) reference and the [markdown-negotiation skill](https://isitagentready.com/.well-known/agent-skills/markdown-negotiation/SKILL.md) both specify this header.

## Test plan

After the Vercel preview deploys:

- [ ] `curl -I -H "Accept: text/markdown" <preview>/api-reference/introduction` returns `content-type: text/markdown; charset=utf-8`
- [ ] `curl -I <preview>/api-reference/introduction` (no Accept) returns `content-type: text/html; charset=utf-8`
- [ ] Both responses include `vary: accept`
- [ ] Direct `.md` fetch still works: `curl -I <preview>/api-reference/introduction.md`
- [ ] Scan with `https://isitagentready.com` — `checks.contentAccessibility.markdownNegotiation.status` returns `pass`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTTP response headers to improve content negotiation and optimize caching behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->