### PR TITLE
Document bucket CORS requirement for external S3 backends

### DIFF
--- a/docs/self-hosting/methods/install-methods-commercial/kubernetes.md
+++ b/docs/self-hosting/methods/install-methods-commercial/kubernetes.md
@@ -280,6 +280,34 @@ airgapped:
 | env.aws_s3_endpoint_url               |                    |          | External `S3` (or compatible) storage service providers shares a `endpoint_url` for the integration purpose for the application to connect and do the necessary upload or download operations. To be provided when `services.minio.local_setup=false`                                                                                                 |
 | env.use_storage_proxy                 |       false        |          | When set to `true`, all S3 (or compatible) file GET requests from the browser are proxied through Plane's API service instead of accessing the S3 endpoint directly. Enable this if your storage endpoint is not accessible publicly or you want to control download access through the API.                                                          |
 
+##### Bucket CORS configuration (required for browser uploads to external S3)
+
+When `services.minio.local_setup=false` you must configure CORS on the target bucket. Plane's web UI uploads files directly to your S3 endpoint via presigned POST. When the S3 endpoint is on a different hostname from the Plane web UI, the browser's same-origin policy requires the bucket to answer a CORS preflight; otherwise uploads fail with `net::ERR_FAILED` even though all server-side configuration is correct.
+
+The bundled MinIO setup avoids this by routing the bucket through the same ingress as the web UI (same-origin); external backends are always cross-origin and need explicit CORS configuration.
+
+Apply the following CORS configuration to your bucket, replacing `https://plane.example.com` with your Plane web URL:
+
+```json
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["https://plane.example.com"],
+      "AllowedMethods": ["GET", "HEAD", "PUT", "POST", "DELETE"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": ["ETag"],
+      "MaxAgeSeconds": 3000
+    }
+  ]
+}
+```
+
+```bash
+aws --endpoint-url https://your-s3-endpoint s3api put-bucket-cors \
+  --bucket uploads \
+  --cors-configuration file://cors.json
+```
+
 #### Web Deployment
 
 | Setting                        |                    Default                    | Required | Description                                                                                                                                                                                                        |

--- a/docs/self-hosting/methods/install-methods-commercial/kubernetes.md
+++ b/docs/self-hosting/methods/install-methods-commercial/kubernetes.md
@@ -284,9 +284,11 @@ airgapped:
 
 When `services.minio.local_setup=false` you must configure CORS on the target bucket. Plane's web UI uploads files directly to your S3 endpoint via presigned POST. When the S3 endpoint is on a different hostname from the Plane web UI, the browser's same-origin policy requires the bucket to answer a CORS preflight; otherwise uploads fail with `net::ERR_FAILED` even though all server-side configuration is correct.
 
-The bundled MinIO setup avoids this by routing the bucket through the same ingress as the web UI (same-origin); external backends are always cross-origin and need explicit CORS configuration.
+The bundled MinIO setup avoids this by routing the bucket through the same ingress as the web UI (same-origin). External backends are typically cross-origin and need explicit CORS configuration, unless you front the S3 endpoint with a same-origin reverse proxy or DNS alias.
 
-Apply the following CORS configuration to your bucket, replacing `https://plane.example.com` with your Plane web URL:
+`env.use_storage_proxy=true` only affects browser-initiated GETs (downloads); uploads always go directly to the S3 endpoint via presigned POST and still require bucket CORS.
+
+Apply the following CORS configuration to your bucket, replacing `https://plane.example.com` with your Plane web URL and `<your-bucket-name>` with the value of `env.docstore_bucket` (default `uploads`):
 
 ```json
 {
@@ -304,7 +306,7 @@ Apply the following CORS configuration to your bucket, replacing `https://plane.
 
 ```bash
 aws --endpoint-url https://your-s3-endpoint s3api put-bucket-cors \
-  --bucket uploads \
+  --bucket <your-bucket-name> \
   --cors-configuration file://cors.json
 ```
 

--- a/docs/self-hosting/methods/kubernetes.md
+++ b/docs/self-hosting/methods/kubernetes.md
@@ -282,9 +282,11 @@ airgapped:
 
 When `services.minio.local_setup=false` you must configure CORS on the target bucket. Plane's web UI uploads files directly to your S3 endpoint via presigned POST. When the S3 endpoint is on a different hostname from the Plane web UI, the browser's same-origin policy requires the bucket to answer a CORS preflight; otherwise uploads fail with `net::ERR_FAILED` even though all server-side configuration is correct.
 
-The bundled MinIO setup avoids this by routing the bucket through the same ingress as the web UI (same-origin); external backends are always cross-origin and need explicit CORS configuration.
+The bundled MinIO setup avoids this by routing the bucket through the same ingress as the web UI (same-origin). External backends are typically cross-origin and need explicit CORS configuration, unless you front the S3 endpoint with a same-origin reverse proxy or DNS alias.
 
-Apply the following CORS configuration to your bucket, replacing `https://plane.example.com` with your Plane web URL:
+`env.use_storage_proxy=true` only affects browser-initiated GETs (downloads); uploads always go directly to the S3 endpoint via presigned POST and still require bucket CORS.
+
+Apply the following CORS configuration to your bucket, replacing `https://plane.example.com` with your Plane web URL and `<your-bucket-name>` with the value of `env.docstore_bucket` (default `uploads`):
 
 ```json
 {
@@ -302,7 +304,7 @@ Apply the following CORS configuration to your bucket, replacing `https://plane.
 
 ```bash
 aws --endpoint-url https://your-s3-endpoint s3api put-bucket-cors \
-  --bucket uploads \
+  --bucket <your-bucket-name> \
   --cors-configuration file://cors.json
 ```
 

--- a/docs/self-hosting/methods/kubernetes.md
+++ b/docs/self-hosting/methods/kubernetes.md
@@ -278,6 +278,34 @@ airgapped:
 | env.aws_s3_endpoint_url               |                    |          | External `S3` (or compatible) storage service providers shares a `endpoint_url` for the integration purpose for the application to connect and do the necessary upload or download operations. To be provided when `services.minio.local_setup=false`                                                                                                 |
 | env.use_storage_proxy                 |       false        |          | When set to `true`, all S3 (or compatible) file GET requests from the browser are proxied through Plane's API service instead of accessing the S3 endpoint directly. Enable this if your storage endpoint is not accessible publicly or you want to control download access through the API.                                                          |
 
+##### Bucket CORS configuration (required for browser uploads to external S3)
+
+When `services.minio.local_setup=false` you must configure CORS on the target bucket. Plane's web UI uploads files directly to your S3 endpoint via presigned POST. When the S3 endpoint is on a different hostname from the Plane web UI, the browser's same-origin policy requires the bucket to answer a CORS preflight; otherwise uploads fail with `net::ERR_FAILED` even though all server-side configuration is correct.
+
+The bundled MinIO setup avoids this by routing the bucket through the same ingress as the web UI (same-origin); external backends are always cross-origin and need explicit CORS configuration.
+
+Apply the following CORS configuration to your bucket, replacing `https://plane.example.com` with your Plane web URL:
+
+```json
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["https://plane.example.com"],
+      "AllowedMethods": ["GET", "HEAD", "PUT", "POST", "DELETE"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": ["ETag"],
+      "MaxAgeSeconds": 3000
+    }
+  ]
+}
+```
+
+```bash
+aws --endpoint-url https://your-s3-endpoint s3api put-bucket-cors \
+  --bucket uploads \
+  --cors-configuration file://cors.json
+```
+
 #### Web Deployment
 
 | Setting                        |                    Default                    | Required | Description                                                                                                                                                                                                        |


### PR DESCRIPTION
## Summary

Adds a "Bucket CORS configuration" subsection to the Doc Store (Minio/S3) Setup block in both Kubernetes guides:

- `docs/self-hosting/methods/kubernetes.md`
- `docs/self-hosting/methods/install-methods-commercial/kubernetes.md`

Plane's web UI uploads files directly to the S3 endpoint via presigned POST (`apps/api/plane/app/views/issue/attachment.py:136` → `S3Storage.generate_presigned_post`; frontend POSTs to `signedURLResponse.upload_data.url` from `apps/web/core/services/issue/issue_attachment.service.ts:50-67`). When the endpoint is on a different hostname from the web UI, the browser issues a CORS preflight that the bucket must answer. The docs only cover the credentials/region/endpoint envs and don't mention this contract.

Bundled MinIO masks the issue by being routed under the same `appHost` ingress (`charts/plane-{ce,enterprise}/templates/ingress.yaml`), so the upload is same-origin and no preflight is issued. External-S3 deployments are the only ones affected; the symptom is `net::ERR_FAILED` on attachment uploads despite all server-side configuration being correct.

End-to-end verified against an external S3 backend: preflight is rejected as `AccessForbidden: CORSResponse: CORS is not enabled for this bucket` until `put-bucket-cors` is applied with the policy in this PR; afterwards the preflight returns 200 with the expected `Access-Control-Allow-Origin`, `-Allow-Methods`, `-Expose-Headers: ETag`, etc.

Fixes #269.

## Test plan

- [x] `pnpm check:format` clean
- [x] Diff inserts the new subsection between the Doc Store reference table and `#### Web Deployment` in both files; no other content changed
- [x] `pnpm build && pnpm preview` — content renders correctly under "Doc Store (Minio/S3) Setup"

---
*Investigation and authoring assisted by Claude (Anthropic).*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CORS configuration guidance for external S3 buckets in Kubernetes self-hosted deployments
  * Includes example CORS rules and AWS CLI command for bucket setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->