### PR TITLE
docs: add IDP Group Sync API section

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1026,6 +1026,43 @@ export default extendConfig(
                     { text: "Get Current User", link: "/api-reference/user/get-current-user" },
                   ],
                 },
+                {
+                  text: "IDP Group Sync",
+                  collapsed: true,
+                  items: [
+                    { text: "Overview", link: "/api-reference/idp-group-sync/overview" },
+                    { text: "Get Group Sync Config", link: "/api-reference/idp-group-sync/get-group-sync-config" },
+                    {
+                      text: "Update Group Sync Config",
+                      link: "/api-reference/idp-group-sync/update-group-sync-config",
+                    },
+                    { text: "List Project Mappings", link: "/api-reference/idp-group-sync/list-project-mappings" },
+                    { text: "Create Project Mapping", link: "/api-reference/idp-group-sync/create-project-mapping" },
+                    { text: "Get Project Mapping", link: "/api-reference/idp-group-sync/get-project-mapping" },
+                    { text: "Update Project Mapping", link: "/api-reference/idp-group-sync/update-project-mapping" },
+                    { text: "Delete Project Mapping", link: "/api-reference/idp-group-sync/delete-project-mapping" },
+                    {
+                      text: "List Workspace Mappings",
+                      link: "/api-reference/idp-group-sync/list-workspace-mappings",
+                    },
+                    {
+                      text: "Create Workspace Mapping",
+                      link: "/api-reference/idp-group-sync/create-workspace-mapping",
+                    },
+                    {
+                      text: "Get Workspace Mapping",
+                      link: "/api-reference/idp-group-sync/get-workspace-mapping",
+                    },
+                    {
+                      text: "Update Workspace Mapping",
+                      link: "/api-reference/idp-group-sync/update-workspace-mapping",
+                    },
+                    {
+                      text: "Delete Workspace Mapping",
+                      link: "/api-reference/idp-group-sync/delete-workspace-mapping",
+                    },
+                  ],
+                },
               ],
             },
           ],

--- a/docs/api-reference/idp-group-sync/create-project-mapping.md
+++ b/docs/api-reference/idp-group-sync/create-project-mapping.md
@@ -1,0 +1,153 @@
+---
+title: Create project group mapping
+description: Create a project group mapping via Plane API. HTTP request format, parameters, scopes, and example responses for create project group mapping.
+keywords: plane, plane api, rest api, api integration, idp group sync, create project group mapping
+---
+
+# Create project group mapping
+
+<div class="api-endpoint-badge">
+  <span class="method post">POST</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/project-mappings/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Create a new IdP group → project mapping. Use `project` to map to a specific project, or `all_projects: true` to map to all projects in the workspace. These two fields are mutually exclusive.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Body Parameters
+
+<div class="params-list">
+
+<ApiParam name="idp_group_name" type="string" :required="true">
+
+The name of the IdP group to map.
+
+</ApiParam>
+
+<ApiParam name="role" type="string" :required="true">
+
+Project role slug to assign to members of the IdP group (e.g. `member`, `admin`, `guest`).
+
+</ApiParam>
+
+<ApiParam name="project" type="string" :required="false">
+
+Project identifier to map the group to (e.g. `ENG`). Mutually exclusive with `all_projects`.
+
+</ApiParam>
+
+<ApiParam name="all_projects" type="boolean" :required="false">
+
+When `true`, maps the group to all projects in the workspace. Mutually exclusive with `project`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:write`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="Create project group mapping" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X POST \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/" \
+  -H "X-API-Key: $PLANE_API_KEY" \
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "idp_group_name": "engineering",
+  "project": "ENG",
+  "role": "member"
+}'
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.post(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/",
+    headers={"X-API-Key": "your-api-key"},
+    json={
+      "idp_group_name": "engineering",
+      "project": "ENG",
+      "role": "member"
+    }
+)
+print(response.json())
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/", {
+  method: "POST",
+  headers: {
+    "X-API-Key": "your-api-key",
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    idp_group_name: "engineering",
+    project: "ENG",
+    role: "member",
+  }),
+});
+const data = await response.json();
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="201">
+
+```json
+{
+  "id": "661f9511-f30c-52e5-b827-557766551111",
+  "idp_group_name": "engineering",
+  "project": "ENG",
+  "all_projects": false,
+  "role": "member",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/create-workspace-mapping.md
+++ b/docs/api-reference/idp-group-sync/create-workspace-mapping.md
@@ -1,0 +1,136 @@
+---
+title: Create workspace group mapping
+description: Create a workspace group mapping via Plane API. HTTP request format, parameters, scopes, and example responses for create workspace group mapping.
+keywords: plane, plane api, rest api, api integration, idp group sync, create workspace group mapping
+---
+
+# Create workspace group mapping
+
+<div class="api-endpoint-badge">
+  <span class="method post">POST</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/workspace-mappings/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Create a new IdP group → workspace role mapping.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Body Parameters
+
+<div class="params-list">
+
+<ApiParam name="idp_group_name" type="string" :required="true">
+
+The name of the IdP group to map.
+
+</ApiParam>
+
+<ApiParam name="role" type="string" :required="true">
+
+Workspace role slug to assign to members of the IdP group (e.g. `member`, `admin`).
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:write`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="Create workspace group mapping" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X POST \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/" \
+  -H "X-API-Key: $PLANE_API_KEY" \
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "idp_group_name": "leadership",
+  "role": "admin"
+}'
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.post(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/",
+    headers={"X-API-Key": "your-api-key"},
+    json={
+      "idp_group_name": "leadership",
+      "role": "admin"
+    }
+)
+print(response.json())
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/", {
+  method: "POST",
+  headers: {
+    "X-API-Key": "your-api-key",
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    idp_group_name: "leadership",
+    role: "admin",
+  }),
+});
+const data = await response.json();
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="201">
+
+```json
+{
+  "id": "772g0622-g41d-63f6-c938-668877662222",
+  "idp_group_name": "leadership",
+  "role": "admin",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/delete-project-mapping.md
+++ b/docs/api-reference/idp-group-sync/delete-project-mapping.md
@@ -1,0 +1,102 @@
+---
+title: Delete project group mapping
+description: Delete a project group mapping via Plane API. HTTP request format, parameters, scopes, and example responses for delete project group mapping.
+keywords: plane, plane api, rest api, api integration, idp group sync, delete project group mapping
+---
+
+# Delete project group mapping
+
+<div class="api-endpoint-badge">
+  <span class="method delete">DELETE</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/project-mappings/{mapping_id}/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Delete an IdP group → project mapping.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+<ApiParam name="mapping_id" type="string" :required="true">
+
+The unique identifier of the project group mapping.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:write`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="Delete project group mapping" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X DELETE \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/" \
+  -H "X-API-Key: $PLANE_API_KEY"
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN"
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.delete(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/",
+    headers={"X-API-Key": "your-api-key"}
+)
+print(response.status_code)
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/",
+  {
+    method: "DELETE",
+    headers: {
+      "X-API-Key": "your-api-key",
+    },
+  }
+);
+console.log(response.status);
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="204">
+
+No response body.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/delete-workspace-mapping.md
+++ b/docs/api-reference/idp-group-sync/delete-workspace-mapping.md
@@ -1,0 +1,102 @@
+---
+title: Delete workspace group mapping
+description: Delete a workspace group mapping via Plane API. HTTP request format, parameters, scopes, and example responses for delete workspace group mapping.
+keywords: plane, plane api, rest api, api integration, idp group sync, delete workspace group mapping
+---
+
+# Delete workspace group mapping
+
+<div class="api-endpoint-badge">
+  <span class="method delete">DELETE</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/workspace-mappings/{mapping_id}/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Delete an IdP group → workspace role mapping.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+<ApiParam name="mapping_id" type="string" :required="true">
+
+The unique identifier of the workspace group mapping.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:write`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="Delete workspace group mapping" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X DELETE \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/772g0622-g41d-63f6-c938-668877662222/" \
+  -H "X-API-Key: $PLANE_API_KEY"
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN"
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.delete(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/772g0622-g41d-63f6-c938-668877662222/",
+    headers={"X-API-Key": "your-api-key"}
+)
+print(response.status_code)
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/772g0622-g41d-63f6-c938-668877662222/",
+  {
+    method: "DELETE",
+    headers: {
+      "X-API-Key": "your-api-key",
+    },
+  }
+);
+console.log(response.status);
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="204">
+
+No response body.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/get-group-sync-config.md
+++ b/docs/api-reference/idp-group-sync/get-group-sync-config.md
@@ -1,0 +1,104 @@
+---
+title: Get group sync config
+description: Get IdP group sync configuration via Plane API. HTTP request format, parameters, scopes, and example responses for get group sync config.
+keywords: plane, plane api, rest api, api integration, idp group sync, get group sync config
+---
+
+# Get group sync config
+
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/config/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Retrieve the IdP group sync configuration for the workspace. Auto-creates the config with defaults on first access.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:read`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="Get group sync config" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X GET \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/config/" \
+  -H "X-API-Key: $PLANE_API_KEY"
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN"
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.get(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/config/",
+    headers={"X-API-Key": "your-api-key"}
+)
+print(response.json())
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/config/", {
+  headers: {
+    "X-API-Key": "your-api-key",
+  },
+});
+const data = await response.json();
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "is_enabled": true,
+  "sync_on_login": true,
+  "auto_remove": false,
+  "sync_offline": false,
+  "group_attribute_key": "groups",
+  "default_workspace_role": "member",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/get-group-sync-config.md
+++ b/docs/api-reference/idp-group-sync/get-group-sync-config.md
@@ -33,6 +33,69 @@ The workspace_slug represents the unique workspace identifier for a workspace in
 
 <div class="params-section">
 
+### Response Attributes
+
+<div class="params-list">
+
+<ApiParam name="id" type="string">
+
+Unique identifier of the config.
+
+</ApiParam>
+
+<ApiParam name="is_enabled" type="boolean">
+
+Whether IdP group sync is enabled for the workspace.
+
+</ApiParam>
+
+<ApiParam name="sync_on_login" type="boolean">
+
+Sync group memberships automatically on user login.
+
+</ApiParam>
+
+<ApiParam name="auto_remove" type="boolean">
+
+Automatically remove users from projects or workspace when removed from their IdP group.
+
+</ApiParam>
+
+<ApiParam name="sync_offline" type="boolean">
+
+Allow sync to run outside of login events.
+
+</ApiParam>
+
+<ApiParam name="group_attribute_key" type="string">
+
+The IdP claim key that contains group membership data (e.g. `groups`).
+
+</ApiParam>
+
+<ApiParam name="default_workspace_role" type="string">
+
+Role slug assigned to users when added to the workspace via group sync.
+
+</ApiParam>
+
+<ApiParam name="created_at" type="timestamp">
+
+The timestamp of when the config was created.
+
+</ApiParam>
+
+<ApiParam name="updated_at" type="timestamp">
+
+The timestamp of when the config was last updated.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
 ### Scopes
 
 `workspaces.group_sync:read`

--- a/docs/api-reference/idp-group-sync/get-project-mapping.md
+++ b/docs/api-reference/idp-group-sync/get-project-mapping.md
@@ -39,6 +39,57 @@ The unique identifier of the project group mapping.
 
 <div class="params-section">
 
+### Response Attributes
+
+<div class="params-list">
+
+<ApiParam name="id" type="string">
+
+Unique identifier of the mapping.
+
+</ApiParam>
+
+<ApiParam name="idp_group_name" type="string">
+
+The name of the IdP group.
+
+</ApiParam>
+
+<ApiParam name="project" type="string">
+
+Project identifier the group is mapped to. `null` when `all_projects` is `true`.
+
+</ApiParam>
+
+<ApiParam name="all_projects" type="boolean">
+
+Whether the group is mapped to all projects in the workspace.
+
+</ApiParam>
+
+<ApiParam name="role" type="string">
+
+Role slug assigned to group members within the project.
+
+</ApiParam>
+
+<ApiParam name="created_at" type="timestamp">
+
+The timestamp of when the mapping was created.
+
+</ApiParam>
+
+<ApiParam name="updated_at" type="timestamp">
+
+The timestamp of when the mapping was last updated.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
 ### Scopes
 
 `workspaces.group_sync:read`

--- a/docs/api-reference/idp-group-sync/get-project-mapping.md
+++ b/docs/api-reference/idp-group-sync/get-project-mapping.md
@@ -1,0 +1,111 @@
+---
+title: Get project group mapping
+description: Get a project group mapping via Plane API. HTTP request format, parameters, scopes, and example responses for get project group mapping.
+keywords: plane, plane api, rest api, api integration, idp group sync, get project group mapping
+---
+
+# Get project group mapping
+
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/project-mappings/{mapping_id}/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Retrieve a single IdP group → project mapping by its ID.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+<ApiParam name="mapping_id" type="string" :required="true">
+
+The unique identifier of the project group mapping.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:read`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="Get project group mapping" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X GET \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/" \
+  -H "X-API-Key: $PLANE_API_KEY"
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN"
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.get(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/",
+    headers={"X-API-Key": "your-api-key"}
+)
+print(response.json())
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/",
+  {
+    headers: {
+      "X-API-Key": "your-api-key",
+    },
+  }
+);
+const data = await response.json();
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "661f9511-f30c-52e5-b827-557766551111",
+  "idp_group_name": "engineering",
+  "project": "ENG",
+  "all_projects": false,
+  "role": "member",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/get-workspace-mapping.md
+++ b/docs/api-reference/idp-group-sync/get-workspace-mapping.md
@@ -1,0 +1,109 @@
+---
+title: Get workspace group mapping
+description: Get a workspace group mapping via Plane API. HTTP request format, parameters, scopes, and example responses for get workspace group mapping.
+keywords: plane, plane api, rest api, api integration, idp group sync, get workspace group mapping
+---
+
+# Get workspace group mapping
+
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/workspace-mappings/{mapping_id}/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Retrieve a single IdP group → workspace role mapping by its ID.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+<ApiParam name="mapping_id" type="string" :required="true">
+
+The unique identifier of the workspace group mapping.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:read`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="Get workspace group mapping" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X GET \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/772g0622-g41d-63f6-c938-668877662222/" \
+  -H "X-API-Key: $PLANE_API_KEY"
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN"
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.get(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/772g0622-g41d-63f6-c938-668877662222/",
+    headers={"X-API-Key": "your-api-key"}
+)
+print(response.json())
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/772g0622-g41d-63f6-c938-668877662222/",
+  {
+    headers: {
+      "X-API-Key": "your-api-key",
+    },
+  }
+);
+const data = await response.json();
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "772g0622-g41d-63f6-c938-668877662222",
+  "idp_group_name": "leadership",
+  "role": "admin",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/get-workspace-mapping.md
+++ b/docs/api-reference/idp-group-sync/get-workspace-mapping.md
@@ -39,6 +39,45 @@ The unique identifier of the workspace group mapping.
 
 <div class="params-section">
 
+### Response Attributes
+
+<div class="params-list">
+
+<ApiParam name="id" type="string">
+
+Unique identifier of the mapping.
+
+</ApiParam>
+
+<ApiParam name="idp_group_name" type="string">
+
+The name of the IdP group.
+
+</ApiParam>
+
+<ApiParam name="role" type="string">
+
+Role slug assigned to group members within the workspace.
+
+</ApiParam>
+
+<ApiParam name="created_at" type="timestamp">
+
+The timestamp of when the mapping was created.
+
+</ApiParam>
+
+<ApiParam name="updated_at" type="timestamp">
+
+The timestamp of when the mapping was last updated.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
 ### Scopes
 
 `workspaces.group_sync:read`

--- a/docs/api-reference/idp-group-sync/list-project-mappings.md
+++ b/docs/api-reference/idp-group-sync/list-project-mappings.md
@@ -33,6 +33,57 @@ The workspace_slug represents the unique workspace identifier for a workspace in
 
 <div class="params-section">
 
+### Response Attributes
+
+<div class="params-list">
+
+<ApiParam name="id" type="string">
+
+Unique identifier of the mapping.
+
+</ApiParam>
+
+<ApiParam name="idp_group_name" type="string">
+
+The name of the IdP group.
+
+</ApiParam>
+
+<ApiParam name="project" type="string">
+
+Project identifier the group is mapped to. `null` when `all_projects` is `true`.
+
+</ApiParam>
+
+<ApiParam name="all_projects" type="boolean">
+
+Whether the group is mapped to all projects in the workspace.
+
+</ApiParam>
+
+<ApiParam name="role" type="string">
+
+Role slug assigned to group members within the project.
+
+</ApiParam>
+
+<ApiParam name="created_at" type="timestamp">
+
+The timestamp of when the mapping was created.
+
+</ApiParam>
+
+<ApiParam name="updated_at" type="timestamp">
+
+The timestamp of when the mapping was last updated.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
 ### Scopes
 
 `workspaces.group_sync:read`

--- a/docs/api-reference/idp-group-sync/list-project-mappings.md
+++ b/docs/api-reference/idp-group-sync/list-project-mappings.md
@@ -1,0 +1,113 @@
+---
+title: List project group mappings
+description: List project group mappings via Plane API. HTTP request format, parameters, scopes, and example responses for list project group mappings.
+keywords: plane, plane api, rest api, api integration, idp group sync, list project group mappings
+---
+
+# List project group mappings
+
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/project-mappings/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Retrieve all IdP group → project mappings for the workspace.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:read`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="List project group mappings" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X GET \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/" \
+  -H "X-API-Key: $PLANE_API_KEY"
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN"
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.get(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/",
+    headers={"X-API-Key": "your-api-key"}
+)
+print(response.json())
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/", {
+  headers: {
+    "X-API-Key": "your-api-key",
+  },
+});
+const data = await response.json();
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="200">
+
+```json
+[
+  {
+    "id": "661f9511-f30c-52e5-b827-557766551111",
+    "idp_group_name": "engineering",
+    "project": "ENG",
+    "all_projects": false,
+    "role": "member",
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:00:00Z"
+  },
+  {
+    "id": "772g0622-g41d-63f6-c938-668877662222",
+    "idp_group_name": "all-staff",
+    "project": null,
+    "all_projects": true,
+    "role": "guest",
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:00:00Z"
+  }
+]
+```
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/list-workspace-mappings.md
+++ b/docs/api-reference/idp-group-sync/list-workspace-mappings.md
@@ -33,6 +33,45 @@ The workspace_slug represents the unique workspace identifier for a workspace in
 
 <div class="params-section">
 
+### Response Attributes
+
+<div class="params-list">
+
+<ApiParam name="id" type="string">
+
+Unique identifier of the mapping.
+
+</ApiParam>
+
+<ApiParam name="idp_group_name" type="string">
+
+The name of the IdP group.
+
+</ApiParam>
+
+<ApiParam name="role" type="string">
+
+Role slug assigned to group members within the workspace.
+
+</ApiParam>
+
+<ApiParam name="created_at" type="timestamp">
+
+The timestamp of when the mapping was created.
+
+</ApiParam>
+
+<ApiParam name="updated_at" type="timestamp">
+
+The timestamp of when the mapping was last updated.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
 ### Scopes
 
 `workspaces.group_sync:read`

--- a/docs/api-reference/idp-group-sync/list-workspace-mappings.md
+++ b/docs/api-reference/idp-group-sync/list-workspace-mappings.md
@@ -1,0 +1,109 @@
+---
+title: List workspace group mappings
+description: List workspace group mappings via Plane API. HTTP request format, parameters, scopes, and example responses for list workspace group mappings.
+keywords: plane, plane api, rest api, api integration, idp group sync, list workspace group mappings
+---
+
+# List workspace group mappings
+
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/workspace-mappings/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Retrieve all IdP group → workspace role mappings for the workspace.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:read`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="List workspace group mappings" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X GET \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/" \
+  -H "X-API-Key: $PLANE_API_KEY"
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN"
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.get(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/",
+    headers={"X-API-Key": "your-api-key"}
+)
+print(response.json())
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/", {
+  headers: {
+    "X-API-Key": "your-api-key",
+  },
+});
+const data = await response.json();
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="200">
+
+```json
+[
+  {
+    "id": "772g0622-g41d-63f6-c938-668877662222",
+    "idp_group_name": "leadership",
+    "role": "admin",
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:00:00Z"
+  },
+  {
+    "id": "883h1733-h52e-74g7-d049-779988773333",
+    "idp_group_name": "engineering",
+    "role": "member",
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:00:00Z"
+  }
+]
+```
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/overview.md
+++ b/docs/api-reference/idp-group-sync/overview.md
@@ -1,0 +1,162 @@
+---
+title: Overview
+description: Plane IDP Group Sync API overview. Learn about endpoints, request/response format, and how to manage IdP group sync configuration and mappings via REST API.
+keywords: plane, plane api, rest api, api integration, idp group sync, group sync config, project mappings, workspace mappings
+---
+
+# Overview
+
+IDP Group Sync lets workspace admins programmatically manage how IdP groups map to Plane projects and workspaces. All endpoints are workspace-scoped and require workspace admin permissions.
+
+<div class="api-two-column">
+<div class="api-left">
+
+### The Group Sync Config Object
+
+### Attributes
+
+- `id` _uuid_
+
+  Unique identifier of the config.
+
+- `is_enabled` _boolean_
+
+  Whether IdP group sync is enabled for the workspace.
+
+- `sync_on_login` _boolean_
+
+  Sync group memberships automatically on user login.
+
+- `auto_remove` _boolean_
+
+  Automatically remove users from projects/workspace when they are removed from the IdP group.
+
+- `sync_offline` _boolean_
+
+  Allow sync to run outside of login events.
+
+- `group_attribute_key` _string_
+
+  The IdP claim key that contains group membership data (e.g. `groups`).
+
+- `default_workspace_role` _string_
+
+  Role slug assigned to users when added to the workspace via group sync.
+
+- `created_at` _timestamp_
+
+  The timestamp of when the config was created.
+
+- `updated_at` _timestamp_
+
+  The timestamp of when the config was last updated.
+
+### The Project Group Mapping Object
+
+### Attributes
+
+- `id` _uuid_
+
+  Unique identifier of the mapping.
+
+- `idp_group_name` _string_
+
+  The name of the IdP group to map.
+
+- `project` _string_
+
+  Project identifier the group is mapped to. Mutually exclusive with `all_projects`.
+
+- `all_projects` _boolean_
+
+  When `true`, maps the group to all projects in the workspace. Mutually exclusive with `project`.
+
+- `role` _string_
+
+  Role slug assigned to group members within the project.
+
+- `created_at` _timestamp_
+
+  The timestamp of when the mapping was created.
+
+- `updated_at` _timestamp_
+
+  The timestamp of when the mapping was last updated.
+
+### The Workspace Group Mapping Object
+
+### Attributes
+
+- `id` _uuid_
+
+  Unique identifier of the mapping.
+
+- `idp_group_name` _string_
+
+  The name of the IdP group to map.
+
+- `role` _string_
+
+  Role slug assigned to group members within the workspace.
+
+- `created_at` _timestamp_
+
+  The timestamp of when the mapping was created.
+
+- `updated_at` _timestamp_
+
+  The timestamp of when the mapping was last updated.
+
+</div>
+<div class="api-right">
+
+<ResponsePanel status="200" title="THE GROUP SYNC CONFIG OBJECT">
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "is_enabled": true,
+  "sync_on_login": true,
+  "auto_remove": false,
+  "sync_offline": false,
+  "group_attribute_key": "groups",
+  "default_workspace_role": "member",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+<ResponsePanel status="200" title="THE PROJECT GROUP MAPPING OBJECT">
+
+```json
+{
+  "id": "661f9511-f30c-52e5-b827-557766551111",
+  "idp_group_name": "engineering",
+  "project": "ENG",
+  "all_projects": false,
+  "role": "member",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+<ResponsePanel status="200" title="THE WORKSPACE GROUP MAPPING OBJECT">
+
+```json
+{
+  "id": "772g0622-g41d-63f6-c938-668877662222",
+  "idp_group_name": "leadership",
+  "role": "admin",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+</div>
+</div>

--- a/docs/api-reference/idp-group-sync/update-group-sync-config.md
+++ b/docs/api-reference/idp-group-sync/update-group-sync-config.md
@@ -1,0 +1,176 @@
+---
+title: Update group sync config
+description: Update IdP group sync configuration via Plane API. HTTP request format, parameters, scopes, and example responses for update group sync config.
+keywords: plane, plane api, rest api, api integration, idp group sync, update group sync config
+---
+
+# Update group sync config
+
+<div class="api-endpoint-badge">
+  <span class="method patch">PATCH</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/config/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Update the IdP group sync configuration for the workspace. Supports partial updates — only include fields you want to change.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Body Parameters
+
+<div class="params-list">
+
+<ApiParam name="is_enabled" type="boolean" :required="false">
+
+Enable or disable IdP group sync for the workspace.
+
+</ApiParam>
+
+<ApiParam name="sync_on_login" type="boolean" :required="false">
+
+Sync group memberships automatically on user login.
+
+</ApiParam>
+
+<ApiParam name="auto_remove" type="boolean" :required="false">
+
+Automatically remove users from projects or workspace when removed from their IdP group.
+
+</ApiParam>
+
+<ApiParam name="sync_offline" type="boolean" :required="false">
+
+Allow sync to run outside of login events.
+
+</ApiParam>
+
+<ApiParam name="group_attribute_key" type="string" :required="false">
+
+The IdP claim key that contains group membership data (e.g. `groups`).
+
+</ApiParam>
+
+<ApiParam name="default_workspace_role" type="string" :required="false">
+
+Role slug assigned to users when added to the workspace via group sync.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:write`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="Update group sync config" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X PATCH \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/config/" \
+  -H "X-API-Key: $PLANE_API_KEY" \
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "is_enabled": true,
+  "sync_on_login": true,
+  "auto_remove": false,
+  "sync_offline": false,
+  "group_attribute_key": "groups",
+  "default_workspace_role": "member"
+}'
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.patch(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/config/",
+    headers={"X-API-Key": "your-api-key"},
+    json={
+      "is_enabled": True,
+      "sync_on_login": True,
+      "auto_remove": False,
+      "sync_offline": False,
+      "group_attribute_key": "groups",
+      "default_workspace_role": "member"
+    }
+)
+print(response.json())
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/config/", {
+  method: "PATCH",
+  headers: {
+    "X-API-Key": "your-api-key",
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    is_enabled: true,
+    sync_on_login: true,
+    auto_remove: false,
+    sync_offline: false,
+    group_attribute_key: "groups",
+    default_workspace_role: "member",
+  }),
+});
+const data = await response.json();
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "is_enabled": true,
+  "sync_on_login": true,
+  "auto_remove": false,
+  "sync_offline": false,
+  "group_attribute_key": "groups",
+  "default_workspace_role": "member",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/update-project-mapping.md
+++ b/docs/api-reference/idp-group-sync/update-project-mapping.md
@@ -1,0 +1,152 @@
+---
+title: Update project group mapping
+description: Update a project group mapping via Plane API. HTTP request format, parameters, scopes, and example responses for update project group mapping.
+keywords: plane, plane api, rest api, api integration, idp group sync, update project group mapping
+---
+
+# Update project group mapping
+
+<div class="api-endpoint-badge">
+  <span class="method patch">PATCH</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/project-mappings/{mapping_id}/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Update an existing IdP group → project mapping. Supports partial updates.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+<ApiParam name="mapping_id" type="string" :required="true">
+
+The unique identifier of the project group mapping.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Body Parameters
+
+<div class="params-list">
+
+<ApiParam name="idp_group_name" type="string" :required="false">
+
+The name of the IdP group to map.
+
+</ApiParam>
+
+<ApiParam name="role" type="string" :required="false">
+
+Project role slug to assign to members of the IdP group (e.g. `member`, `admin`, `guest`).
+
+</ApiParam>
+
+<ApiParam name="project" type="string" :required="false">
+
+Project identifier to map the group to (e.g. `ENG`). Mutually exclusive with `all_projects`.
+
+</ApiParam>
+
+<ApiParam name="all_projects" type="boolean" :required="false">
+
+When `true`, maps the group to all projects in the workspace. Mutually exclusive with `project`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:write`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="Update project group mapping" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X PATCH \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/" \
+  -H "X-API-Key: $PLANE_API_KEY" \
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "role": "admin"
+}'
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.patch(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/",
+    headers={"X-API-Key": "your-api-key"},
+    json={"role": "admin"}
+)
+print(response.json())
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/",
+  {
+    method: "PATCH",
+    headers: {
+      "X-API-Key": "your-api-key",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ role: "admin" }),
+  }
+);
+const data = await response.json();
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "661f9511-f30c-52e5-b827-557766551111",
+  "idp_group_name": "engineering",
+  "project": "ENG",
+  "all_projects": false,
+  "role": "admin",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/idp-group-sync/update-workspace-mapping.md
+++ b/docs/api-reference/idp-group-sync/update-workspace-mapping.md
@@ -1,0 +1,138 @@
+---
+title: Update workspace group mapping
+description: Update a workspace group mapping via Plane API. HTTP request format, parameters, scopes, and example responses for update workspace group mapping.
+keywords: plane, plane api, rest api, api integration, idp group sync, update workspace group mapping
+---
+
+# Update workspace group mapping
+
+<div class="api-endpoint-badge">
+  <span class="method patch">PATCH</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/workspace-mappings/{mapping_id}/</span>
+</div>
+
+<div class="api-two-column">
+<div class="api-left">
+
+Update an existing IdP group → workspace role mapping. Supports partial updates.
+
+<div class="params-section">
+
+### Path Parameters
+
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+<ApiParam name="mapping_id" type="string" :required="true">
+
+The unique identifier of the workspace group mapping.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Body Parameters
+
+<div class="params-list">
+
+<ApiParam name="idp_group_name" type="string" :required="false">
+
+The name of the IdP group to map.
+
+</ApiParam>
+
+<ApiParam name="role" type="string" :required="false">
+
+Workspace role slug to assign to members of the IdP group (e.g. `member`, `admin`).
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
+
+`workspaces.group_sync:write`
+
+</div>
+
+</div>
+
+<div class="api-right">
+
+<CodePanel title="Update workspace group mapping" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X PATCH \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/772g0622-g41d-63f6-c938-668877662222/" \
+  -H "X-API-Key: $PLANE_API_KEY" \
+  # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "role": "member"
+}'
+```
+
+</template>
+<template #python>
+
+```python
+import requests
+
+response = requests.patch(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/772g0622-g41d-63f6-c938-668877662222/",
+    headers={"X-API-Key": "your-api-key"},
+    json={"role": "member"}
+)
+print(response.json())
+```
+
+</template>
+<template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/workspace-mappings/772g0622-g41d-63f6-c938-668877662222/",
+  {
+    method: "PATCH",
+    headers: {
+      "X-API-Key": "your-api-key",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ role: "member" }),
+  }
+);
+const data = await response.json();
+```
+
+</template>
+</CodePanel>
+
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "772g0622-g41d-63f6-c938-668877662222",
+  "idp_group_name": "leadership",
+  "role": "member",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+</ResponsePanel>
+
+</div>
+
+</div>


### PR DESCRIPTION
## Summary

- Adds documentation for the new IdP group sync endpoints introduced in [plane-ee#7635](https://github.com/makeplane/plane-ee/pull/7635)
- New section: **IDP Group Sync** in the API reference sidebar, placed after Users
- 13 pages covering all three resource groups:
  - **Group Sync Config** — get, update
  - **Project Group Mappings** — list, create, get, update, delete
  - **Workspace Group Mappings** — list, create, get, update, delete

## Test plan

- [ ] Verify all pages render correctly under `/api-reference/idp-group-sync/`
- [ ] Verify sidebar shows IDP Group Sync section after Users
- [ ] Verify CI (Prettier + VitePress build) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API reference documentation for IDP Group Sync, including guides for managing project and workspace group mappings, retrieving configurations, and updating sync settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->