### PR TITLE
fix: patch js-yaml DoS (GHSA-h67p-54hq-rp68)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   vite: 6.4.3
   postcss: 8.5.15
   uuid: 11.1.1
+  js-yaml: 3.15.0
 
 importers:
 
@@ -1224,8 +1225,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   katex@0.16.28:
@@ -2848,7 +2849,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -2893,7 +2894,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,19 +13,11 @@ overrides:
   vite: 6.4.3 # was 6.4.2 — GHSA-fx2h-pf6j-xcff (high), GHSA-v6wh-96g9-6wx3
   postcss: 8.5.15 # GHSA-qx2v-qp2m-jg93 (via vite)
   uuid: 11.1.1 # GHSA-w5hq-g745-h8pq (via mermaid; stays in mermaid's ^11 range)
+  js-yaml: 3.15.0 # GHSA-h67p-54hq-rp68 quadratic-DoS via merge-key aliases (via gray-matter; stays in its ^3.13.1 range)
 
 peerDependencyRules:
   allowedVersions:
     vitepress: "2"
-
-auditConfig:
-  ignoreGhsas:
-    # js-yaml 3.x quadratic-DoS via merge-key aliases (CVE-2026-53550).
-    # gray-matter@4.0.3 hard-pins js-yaml 3.x (uses safeLoad/safeDump, removed
-    # in 4.x) and has no newer release; the fix only landed in js-yaml >=4.2.0,
-    # so 3.x cannot be patched. js-yaml here only parses this repo's own
-    # build-time frontmatter (trusted input), so the DoS is not reachable.
-    - GHSA-h67p-54hq-rp68
 
 # Build scripts left disabled (matching prior pnpm 10 behavior — neither was
 # ever approved, and the site builds fine without them). Flip to true to allow.


### PR DESCRIPTION
## Summary

Resolves the single open Dependabot alert — [#32](https://github.com/makeplane/developer-docs/security/dependabot/32), **GHSA-h67p-54hq-rp68** (medium): quadratic-complexity DoS in `js-yaml` via repeated aliases in merge-key handling.

`js-yaml@3.14.2` reaches us transitively:

```
vitepress-plugin-llms → gray-matter@4.0.3 → js-yaml@3.14.2
```

## Changes

- **`pnpm-workspace.yaml`** — add override `js-yaml: 3.15.0` (the official 3.x patch, npm's `v3-legacy` dist-tag and the advisory's first-patched version for the `< 3.15.0` range). `gray-matter` requires `js-yaml ^3.13.1`, so `3.15.0` stays in range and is API-compatible (`safeLoad`/`safeDump` intact — it's a security backport, deps unchanged).
- **`pnpm-workspace.yaml`** — remove the `auditConfig.ignoreGhsas` suppression for this advisory. Its comment claimed the 3.x line "cannot be patched" and the fix only landed in `>= 4.2.0`; that was outdated — `3.15.0` patches the 3.x line, so the alert is now genuinely fixed rather than muted.
- **`pnpm-lock.yaml`** — regenerated (`js-yaml 3.14.2 → 3.15.0`, no other changes).

## Verification

- `pnpm audit` → **No known vulnerabilities found**
- `pnpm build` → **build complete** (exercises js-yaml via build-time frontmatter parsing)
- `pnpm check:format` → **All matched files use Prettier code style**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned `js-yaml` to version 3.15.0 to address a known security advisory.
  * Removed the corresponding audit exclusion so the vulnerability is no longer ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->