### PR TITLE
fix: neutral inline code color and explicit github syntax themes for readability

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,10 @@ export default extendConfig(
   withMermaid(
     defineConfig({
       markdown: {
+        theme: {
+          light: "github-light",
+          dark: "github-dark",
+        },
         config(md) {
           md.use(tabsMarkdownPlugin);
         },

--- a/docs/.vitepress/theme/styles.css
+++ b/docs/.vitepress/theme/styles.css
@@ -97,6 +97,11 @@ html:not(.dark):not([data-theme="dark"]) {
   --color-plane-500: #006399;
   --color-plane-600: #005280;
 
+  /* Inline code — neutral body-text color instead of the VitePress default
+     (brand blue), which is hard to read on the dark pill background.
+     Linked code keeps --vp-code-link-color (brand) so links stay visible. */
+  --vp-code-color: var(--vp-c-text-1);
+
   --docs-divider: #ececec;
 
   --vp-c-bg: #ffffff;
@@ -158,7 +163,7 @@ html:not(.dark):not([data-theme="dark"]) {
 :root[data-variant="voidzero"]:not(.dark):not([data-theme="dark"]),
 :root[data-variant="vitest"]:not(.dark):not([data-theme="dark"]) {
   --color-brand: #006399;
-  --vp-code-color: #006399;
+  --vp-code-color: var(--vp-c-text-1);
 }
 
 /* --- Dark mode --- */


### PR DESCRIPTION
## Problem

Dark-mode inline code was nearly unreadable: `styles.css` hardcoded `--vp-code-color: #006399` (the light-mode brand blue) in a block that also applies in dark mode, producing dark-blue-on-dark text. Even without that, VitePress defaults inline code to the brand color, which reads poorly on the dark pill background.

Before
<img width="2862" height="1240" alt="CleanShot 2026-07-23 at 20 31 25@2x" src="https://github.com/user-attachments/assets/363e2872-1c5e-49fb-a64a-de8ad6bfa014" />

After
<img width="2866" height="1210" alt="CleanShot 2026-07-23 at 20 30 57@2x" src="https://github.com/user-attachments/assets/a6313874-94c5-41a8-b511-f9338749a338" />

## Changes

- `styles.css`: replace the hardcoded `--vp-code-color: #006399` with `var(--vp-c-text-1)` and add the same neutral override in the base `:root` block — inline code now uses the body-text color in both modes (GitHub-style). Code inside links keeps brand blue via `--vp-code-link-color`.
- `config.mts`: declare the syntax themes explicitly (`github-light`/`github-dark`) — same values VitePress defaults to, now pinned and consistent with makeplane/docs.

## Verification

- Served the production build and checked the Download Docker config files page in both modes: inline code (`prime-cli`, `docker-compose.yml`, parameter table pills) is now high-contrast neutral; bash blocks render fine; links keep brand blue.
- `pnpm check:format` and `pnpm build` pass.

Companion PR: makeplane/docs#479