### PR TITLE
docs(self-hosting): add FIPS-enabled deployment guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -299,7 +299,7 @@ export default extendConfig(
                 { text: "Overview", link: "/self-hosting/overview" },
                 { text: "Self-hosting 101", link: "/self-hosting/self-hosting-101" },
                 { text: "Docker Compose", link: "/self-hosting/methods/docker-compose" },
-                { text: "Kubernetes", link: "/self-hosting/methods/kubernetes" }
+                { text: "Kubernetes", link: "/self-hosting/methods/kubernetes" },
               ],
             },
             {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -89,6 +89,7 @@ export default extendConfig(
             ignoreFiles: [
               "self-hosting/methods/install-methods-commercial/docker-compose.md",
               "self-hosting/methods/install-methods-commercial/kubernetes.md",
+              "self-hosting/methods/install-methods-commercial/fips-deployment.md",
             ],
           }),
         ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -299,8 +299,7 @@ export default extendConfig(
                 { text: "Overview", link: "/self-hosting/overview" },
                 { text: "Self-hosting 101", link: "/self-hosting/self-hosting-101" },
                 { text: "Docker Compose", link: "/self-hosting/methods/docker-compose" },
-                { text: "Kubernetes", link: "/self-hosting/methods/kubernetes" },
-                { text: "FIPS deployment", link: "/self-hosting/methods/install-methods-commercial/fips-deployment" },
+                { text: "Kubernetes", link: "/self-hosting/methods/kubernetes" }
               ],
             },
             {
@@ -329,7 +328,6 @@ export default extendConfig(
                 { text: "Self-hosting 101", link: "/self-hosting/self-hosting-101" },
                 { text: "Plane Editions", link: "/self-hosting/editions-and-versions" },
                 { text: "Plane Architecture", link: "/self-hosting/plane-architecture" },
-                { text: "FIPS deployment", link: "/self-hosting/methods/install-methods-commercial/fips-deployment" },
               ],
             },
             {
@@ -352,6 +350,7 @@ export default extendConfig(
                   collapsed: true,
                   items: [{ text: "High availability", link: "/self-hosting/govern/high-availability" }],
                 },
+                { text: "FIPS deployment", link: "/self-hosting/methods/fips-deployment" },
                 { text: "Podman Quadlets", link: "/self-hosting/methods/podman-quadlets" },
                 {
                   text: "Airgapped Edition",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -300,6 +300,7 @@ export default extendConfig(
                 { text: "Self-hosting 101", link: "/self-hosting/self-hosting-101" },
                 { text: "Docker Compose", link: "/self-hosting/methods/docker-compose" },
                 { text: "Kubernetes", link: "/self-hosting/methods/kubernetes" },
+                { text: "FIPS deployment", link: "/self-hosting/methods/install-methods-commercial/fips-deployment" },
               ],
             },
             {
@@ -328,6 +329,7 @@ export default extendConfig(
                 { text: "Self-hosting 101", link: "/self-hosting/self-hosting-101" },
                 { text: "Plane Editions", link: "/self-hosting/editions-and-versions" },
                 { text: "Plane Architecture", link: "/self-hosting/plane-architecture" },
+                { text: "FIPS deployment", link: "/self-hosting/methods/install-methods-commercial/fips-deployment" },
               ],
             },
             {

--- a/docs/self-hosting/methods/fips-deployment.md
+++ b/docs/self-hosting/methods/fips-deployment.md
@@ -73,6 +73,87 @@ As a safeguard, run the FIPS images with `PLANE_REQUIRE_FIPS=1`: the containers 
 start** if the host is not in FIPS mode. Without it, a FIPS image on a non-FIPS host logs a startup
 warning but runs.
 
+## Deploy on Kubernetes
+
+Use the same `plane-enterprise` Helm chart as a [standard Kubernetes install](/self-hosting/methods/kubernetes) -
+FIPS is a values overlay, not a different chart. Three things change:
+
+1. **Nodes** - provision a node pool whose machine image boots in FIPS mode (see
+   [Host prerequisite](#host-prerequisite)). Label it (e.g. `fips: enabled`) and taint it (e.g.
+   `fips=true:NoSchedule`) so only FIPS workloads land there.
+2. **Images** - override every service image to its `-fips` variant.
+3. **Scheduling** - every service must carry the matching `nodeSelector` and `toleration`. A pod
+   that misses them schedules onto a stock node and **silently loses FIPS**.
+
+```yaml
+# values-fips.yaml
+planeVersion: <release-tag>
+
+# Non-root with group 0, matching the FIPS images' group-0-writable directories
+# (see the non-root section below).
+securityContext:
+  enabled: true
+  podSecurityContext:
+    runAsGroup: 0
+    fsGroup: 0
+
+_fips_sched: &fips
+  nodeSelector:
+    fips: enabled
+  tolerations:
+    - key: fips
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
+
+services:
+  api:
+    image: makeplane/backend-commercial-fips
+    <<: *fips
+  web:
+    image: makeplane/web-commercial-fips
+    <<: *fips
+  space:
+    image: makeplane/space-commercial-fips
+    <<: *fips
+  admin:
+    image: makeplane/admin-commercial-fips
+    <<: *fips
+  live:
+    image: makeplane/live-commercial-fips
+    <<: *fips
+  silo:
+    image: makeplane/silo-commercial-fips
+    <<: *fips
+  monitor:
+    image: makeplane/monitor-commercial-fips
+    <<: *fips
+  worker:
+    <<: *fips
+  beatworker:
+    <<: *fips
+  # Every additional service you enable (pi, opensearch, the bundled
+  # datastores, ...) needs the same <<: *fips block.
+  postgres:
+    <<: *fips
+  redis:
+    <<: *fips
+  rabbitmq:
+    <<: *fips
+  minio:
+    <<: *fips
+```
+
+```bash
+helm repo add plane https://helm.plane.so/
+helm upgrade --install plane-app plane/plane-enterprise \
+  --namespace plane --create-namespace \
+  -f values-fips.yaml
+```
+
+On OpenShift, drop the `securityContext` override and see
+[Running under a non-root or arbitrary UID](#running-under-a-non-root-or-arbitrary-uid-openshift).
+
 ## Verify
 
 Each container logs its posture on startup:
@@ -99,6 +180,9 @@ docker exec plane-api sh -c 'echo x | openssl md5'
 # Node services must report FIPS - must print 1
 docker exec plane-live node -p "require('crypto').getFips()"
 ```
+
+On Kubernetes, run the same checks with `kubectl exec` against any application pod, e.g.
+`kubectl -n plane exec deploy/plane-app-api-wl -- cat /proc/sys/crypto/fips_enabled`.
 
 ## Configuration defaults specific to FIPS images
 

--- a/docs/self-hosting/methods/fips-deployment.md
+++ b/docs/self-hosting/methods/fips-deployment.md
@@ -1,5 +1,5 @@
 ---
-title: FIPS-enabled deployment
+title: FIPS deployment
 description: Deploy the FIPS variant of Plane Enterprise on a FIPS-enforcing host, including prerequisites, image list, verification, and scope of coverage.
 keywords: plane fips, fips 140-3 deployment, plane commercial fips, govcloud plane, federal self-hosting, fips enabled containers
 head:
@@ -8,7 +8,7 @@ head:
       content: noindex, nofollow
 ---
 
-# FIPS-enabled deployment
+# FIPS deployment <Badge type="warning" text="Enterprise Grid" />
 
 Plane Enterprise publishes a FIPS variant of every application image alongside the standard set.
 These images are built on Red Hat UBI 10, apply the system-wide FIPS cryptographic policy, and run
@@ -16,14 +16,13 @@ their cryptography against FIPS-validated modules (Red Hat's OpenSSL FIPS provid
 and static services; the Go FIPS 140-3 module for the Go services). They are intended for
 deployments that must meet FIPS 140-3 expectations, such as US Federal or GovCloud environments.
 
-> **The single most important prerequisite:** FIPS mode is a property of the **host**, not of the
-> image. A FIPS image on a non-FIPS host starts cleanly and looks identical from the inside while
-> providing none of the guarantees. Read [Host prerequisite](#host-prerequisite) first.
+::: warning **The single most important prerequisite** 
+FIPS mode is a property of the **host**, not of the image. A FIPS image on a non-FIPS host starts cleanly and looks identical from the inside while providing none of the guarantees. Read [Host prerequisite](#host-prerequisite) first.
+:::
 
 ## Images
 
-The FIPS images use the same names as the standard `-commercial` images with a `-fips` suffix, in
-the `makeplane` Docker Hub organization:
+The FIPS images use the same names as the standard `-commercial` images with a `-fips` suffix, in the `makeplane` Docker Hub organization:
 
 | Service       | Image                                   |
 | ------------- | --------------------------------------- |
@@ -35,17 +34,17 @@ the `makeplane` Docker Hub organization:
 | Silo          | `makeplane/silo-commercial-fips`        |
 | Monitor       | `makeplane/monitor-commercial-fips`     |
 | Email         | `makeplane/email-commercial-fips`       |
-| Plane AI (Pi) | `makeplane/plane-pi-commercial-fips`    |
+| Plane AI      | `makeplane/plane-pi-commercial-fips`    |
 | Proxy         | `makeplane/proxy-commercial-fips`       |
 | Flux          | `makeplane/flux-commercial-fips`        |
 | Node runner   | `makeplane/node-runner-commercial-fips` |
 
-Pin a specific release tag for any accredited deployment rather than tracking `latest` — a known,
+Pin a specific release tag for any accredited deployment rather than tracking `latest` - a known,
 fixed image version is part of the audit trail.
 
-> **Note:** there is no FIPS All-in-One (AIO) image. The AIO image is built on an Alpine base, which
-> has no FIPS-validated cryptography, so a FIPS deployment uses the multi-container Compose stack
-> below, not the AIO image.
+:::info 
+There is no FIPS All-in-One (AIO) image. The AIO image is built on an Alpine base, which has no FIPS-validated cryptography, so a FIPS deployment uses the multi-container Compose stack below, not the AIO image.
+::: 
 
 ## Host prerequisite
 
@@ -58,7 +57,7 @@ cat /proc/sys/crypto/fips_enabled     # must print 1
 
 How you put the host into FIPS mode depends on the distribution and version:
 
-**Amazon Linux 2023, RHEL 8/9 (and Rocky, Alma)** — enable in place, then reboot:
+**Amazon Linux 2023, RHEL 8/9 (and Rocky, Alma)** - enable in place, then reboot:
 
 ```bash
 sudo dnf install -y crypto-policies-scripts
@@ -68,9 +67,9 @@ sudo reboot
 
 On AL2023 `/boot` lives on the root filesystem, so no separate partition is required. On RHEL/Rocky/Alma with a **separate** `/boot` (or `/boot/efi`) partition, that partition must be mounted so `fips-mode-setup` can update the bootloader.
 
-**RHEL 10** — `fips-mode-setup` has been **removed**, and switching an already-installed system to FIPS mode is **not supported**. FIPS mode must be enabled **at install time** by adding `fips=1` to the kernel command line (or `fips = true` in a RHEL image-builder blueprint). A post-install `update-crypto-policies --set FIPS` is **not** sufficient for FIPS 140 compliance — the only supported path on a non-FIPS install is reinstalling.
+**RHEL 10** - `fips-mode-setup` has been **removed**, and switching an already-installed system to FIPS mode is **not supported**. FIPS mode must be enabled **at install time** by adding `fips=1` to the kernel command line (or `fips = true` in a RHEL image-builder blueprint). A post-install `update-crypto-policies --set FIPS` is **not** sufficient for FIPS 140 compliance - the only supported path on a non-FIPS install is reinstalling.
 
-**Other** — boot a vendor FIPS image (a RHEL FIPS AMI, Ubuntu Pro FIPS), or install OpenShift with FIPS enabled.
+**Other** - boot a vendor FIPS image (a RHEL FIPS AMI, Ubuntu Pro FIPS), or install OpenShift with FIPS enabled.
 
 In all cases, the definitive check is the kernel flag above (`/proc/sys/crypto/fips_enabled` = `1`).
 
@@ -82,10 +81,10 @@ start** if the host is not in FIPS mode. Set it to `0` to downgrade that to a st
 The Compose file and its supporting files live in the plane-ee repository under
 `deployments/cli/commercial/`:
 
-- `docker-compose-fips.yml` — the FIPS stack
-- `variables.env` — environment template
-- `README-FIPS.md` — the authoritative operations reference
-- `verify-fips.sh` — the verification script (see [Verify](#verify))
+- `docker-compose-fips.yml` - the FIPS stack
+- `variables.env` - environment template
+- `README-FIPS.md` - the authoritative operations reference
+- `verify-fips.sh` - the verification script (see [Verify](#verify))
 
 ```bash
 # 1. Confirm the host is in FIPS mode (above).
@@ -108,8 +107,7 @@ The Go services (monitor, email, proxy) log a corresponding line, for example
 
 ## Verify
 
-`verify-fips.sh` (shipped in plane-ee under `deployments/cli/commercial/`, alongside the Compose
-file) checks the posture across the running stack — the kernel flag inside each container, that the
+`verify-fips.sh` checks the posture across the running stack - the kernel flag inside each container, that the
 validated OpenSSL provider is loaded and active, that a non-approved digest is refused, that Node's
 `crypto.getFips()` returns 1, and that the Go services report the module. It is designed to exit
 non-zero when a check does not hold, so it can gate a deployment pipeline:
@@ -141,7 +139,7 @@ the following must hold:
    `LDAP_TLS_CA_CERTFILE` at your CA bundle (PEM).
 2. The certificate's CN/SAN matches the host in `LDAP_SERVER_URI`. An IP address or short hostname
    that is not in the certificate's SAN fails hostname verification **even with the correct CA
-   bundle** — use the fully qualified name the certificate was issued for.
+   bundle** - use the fully qualified name the certificate was issued for.
 
 Setting `LDAP_TLS_REQUIRE_CERT=never` restores the previous behaviour and logs a warning on every
 connection.
@@ -157,7 +155,7 @@ images' group-`0`-writable directories.
 
 **OpenShift (`restricted-v2`).** Do **not** set `runAsUser`, `runAsGroup`, or `fsGroup` yourself. The
 SCC assigns an arbitrary high UID that is a member of group `0`, and it allocates `fsGroup` from the
-namespace's `openshift.io/sa.scc.supplemental-groups` range — an explicit `fsGroup: 0` is rejected
+namespace's `openshift.io/sa.scc.supplemental-groups` range - an explicit `fsGroup: 0` is rejected
 unless that range includes `0`. No image change or group override is needed: the images' writable
 directories are already group-`0` writable, which is exactly what the assigned UID needs.
 
@@ -172,7 +170,7 @@ FIPS-enforcing host. Non-approved algorithms are refused.
 
 **The bundled data plane is not FIPS.** The `postgres`, `valkey`, `rabbitmq`, `minio`, and
 `iframely` services in the Compose file are upstream Alpine/musl images with no FIPS-validated
-cryptography — there are no FIPS variants of them. They are suitable for evaluation only. For an
+cryptography - there are no FIPS variants of them. They are suitable for evaluation only. For an
 accreditable deployment, replace them with externally managed datastores on FIPS endpoints and
 repoint the connection variables:
 
@@ -188,15 +186,9 @@ not start.
 
 **TLS termination.** The bundled proxy (Caddy) is built against a FIPS-validated module, but for an
 accredited topology the recommended pattern is to terminate TLS at a validated endpoint in front of
-the deployment — such as a FIPS-enabled load balancer — and have the proxy serve HTTP internally.
+the deployment - such as a FIPS-enabled load balancer - and have the proxy serve HTTP internally.
 
 **FIPS validation applies to the cryptographic modules, not to Plane as a product.** FIPS 140-3
 certificates are held by the module vendors (Red Hat and the Go project). This deployment ensures
 Plane's cryptography _uses_ those validated modules on a compliant host; it does not make Plane
 itself a FIPS-certified product.
-
-## Reference
-
-The authoritative operations reference — including every environment variable and the migration
-notes for moving a standard deployment onto FIPS images — is `README-FIPS.md`, shipped alongside
-the Compose file in `deployments/cli/commercial/`.

--- a/docs/self-hosting/methods/fips-deployment.md
+++ b/docs/self-hosting/methods/fips-deployment.md
@@ -16,7 +16,7 @@ their cryptography against FIPS-validated modules (Red Hat's OpenSSL FIPS provid
 and static services; the Go FIPS 140-3 module for the Go services). They are intended for
 deployments that must meet FIPS 140-3 expectations, such as US Federal or GovCloud environments.
 
-::: warning **The single most important prerequisite** 
+::: warning **The single most important prerequisite**
 FIPS mode is a property of the **host**, not of the image. A FIPS image on a non-FIPS host starts cleanly and looks identical from the inside while providing none of the guarantees. Read [Host prerequisite](#host-prerequisite) first.
 :::
 
@@ -42,9 +42,9 @@ The FIPS images use the same names as the standard `-commercial` images with a `
 Pin a specific release tag for any accredited deployment rather than tracking `latest` - a known,
 fixed image version is part of the audit trail.
 
-:::info 
+:::info
 There is no FIPS All-in-One (AIO) image. The AIO image is built on an Alpine base, which has no FIPS-validated cryptography, so a FIPS deployment uses the multi-container Compose stack below, not the AIO image.
-::: 
+:::
 
 ## Host prerequisite
 
@@ -78,8 +78,10 @@ start** if the host is not in FIPS mode. Set it to `0` to downgrade that to a st
 
 ## Deploy
 
-The Compose file and its supporting files live in the plane-ee repository under
-`deployments/cli/commercial/`:
+Each Plane Enterprise FIPS release ships a deployment bundle containing the files below. The
+Plane Enterprise source repository is private, so these files are not publicly browsable - they
+are distributed with the release. If you don't have the bundle for your release, request it from
+your Plane account team or [contact support](https://plane.so/contact).
 
 - `docker-compose-fips.yml` - the FIPS stack
 - `variables.env` - environment template

--- a/docs/self-hosting/methods/fips-deployment.md
+++ b/docs/self-hosting/methods/fips-deployment.md
@@ -132,8 +132,9 @@ services:
     <<: *fips
   beatworker:
     <<: *fips
-  # Every additional service you enable (pi, opensearch, the bundled
-  # datastores, ...) needs the same <<: *fips block.
+  # Every additional service you enable needs the same <<: *fips block -
+  # e.g. Plane AI also takes image: makeplane/plane-pi-commercial-fips, and
+  # its pi_worker / pi_beat_worker need the block too.
   postgres:
     <<: *fips
   redis:
@@ -215,18 +216,19 @@ use the bundled proxy.
 **Covered.** The Plane application images run their cryptography against FIPS-validated modules on a
 FIPS-enforcing host. Non-approved algorithms are refused.
 
-**The bundled data plane is not FIPS.** The `postgres`, `valkey`, `rabbitmq`, `minio`, and
-`iframely` services in the stack are upstream Alpine/musl images with no FIPS-validated
-cryptography - there are no FIPS variants of them. They are suitable for evaluation only. For an
-accreditable deployment, replace them with externally managed datastores on FIPS endpoints and
-repoint the connection variables:
+**The bundled data plane is not FIPS.** The `postgres`, `valkey`, `rabbitmq`, `minio`,
+`opensearch`, and `iframely` services in the stack are upstream third-party images with no
+FIPS-validated cryptography - there are no FIPS variants of them. They are suitable for evaluation
+only. For an accreditable deployment, replace them with externally managed datastores on FIPS
+endpoints and repoint the connection variables:
 
-| Service       | Replace with                      | Variables                                     |
-| ------------- | --------------------------------- | --------------------------------------------- |
-| `plane-db`    | RDS / Aurora PostgreSQL           | `DATABASE_URL`, `PGHOST`, `POSTGRES_*`        |
-| `plane-redis` | ElastiCache (Valkey/Redis)        | `REDIS_URL`, `REDIS_HOST`, `REDIS_PORT`       |
-| `plane-mq`    | Amazon MQ (RabbitMQ)              | `AMQP_URL`, `RABBITMQ_*`                      |
-| `plane-minio` | S3 on a FIPS endpoint, or similar | `AWS_S3_ENDPOINT_URL`, `AWS_*`, `USE_MINIO=0` |
+| Service       | Replace with                          | Variables                                     |
+| ------------- | ------------------------------------- | --------------------------------------------- |
+| `plane-db`    | RDS / Aurora PostgreSQL               | `DATABASE_URL`, `PGHOST`, `POSTGRES_*`        |
+| `plane-redis` | ElastiCache (Valkey/Redis)            | `REDIS_URL`, `REDIS_HOST`, `REDIS_PORT`       |
+| `plane-mq`    | Amazon MQ (RabbitMQ)                  | `AMQP_URL`, `RABBITMQ_*`                      |
+| `plane-minio` | S3 on a FIPS endpoint, or similar     | `AWS_S3_ENDPOINT_URL`, `AWS_*`, `USE_MINIO=0` |
+| `opensearch`  | Amazon OpenSearch Service, or similar | `OPENSEARCH_URL`, `OPENSEARCH_*`              |
 
 Then set the corresponding `*_REPLICAS` to `0`, or remove those services, so the bundled ones do
 not start.

--- a/docs/self-hosting/methods/fips-deployment.md
+++ b/docs/self-hosting/methods/fips-deployment.md
@@ -10,7 +10,7 @@ head:
 
 # FIPS deployment <Badge type="warning" text="Enterprise Grid" />
 
-Plane Enterprise publishes a FIPS variant of every application image alongside the standard set.
+Plane publishes a FIPS variant of every application image alongside the standard set.
 These images are built on Red Hat UBI 10, apply the system-wide FIPS cryptographic policy, and run
 their cryptography against FIPS-validated modules (Red Hat's OpenSSL FIPS provider for the Python
 and static services; the Go FIPS 140-3 module for the Go services). They are intended for

--- a/docs/self-hosting/methods/fips-deployment.md
+++ b/docs/self-hosting/methods/fips-deployment.md
@@ -65,27 +65,19 @@ sudo fips-mode-setup --enable
 sudo reboot
 ```
 
-On AL2023 `/boot` lives on the root filesystem, so no separate partition is required. On RHEL/Rocky/Alma with a **separate** `/boot` (or `/boot/efi`) partition, that partition must be mounted so `fips-mode-setup` can update the bootloader.
-
-**RHEL 10** - `fips-mode-setup` has been **removed**, and switching an already-installed system to FIPS mode is **not supported**. FIPS mode must be enabled **at install time** by adding `fips=1` to the kernel command line (or `fips = true` in a RHEL image-builder blueprint). A post-install `update-crypto-policies --set FIPS` is **not** sufficient for FIPS 140 compliance - the only supported path on a non-FIPS install is reinstalling.
+**RHEL 10** - `fips-mode-setup` has been removed and post-install switching is not supported: enable FIPS **at install time** with `fips=1` on the kernel command line.
 
 **Other** - boot a vendor FIPS image (a RHEL FIPS AMI, Ubuntu Pro FIPS), or install OpenShift with FIPS enabled.
-
-In all cases, the definitive check is the kernel flag above (`/proc/sys/crypto/fips_enabled` = `1`).
 
 As a safeguard, the shipped Compose file sets `PLANE_REQUIRE_FIPS=1`, so the containers **refuse to
 start** if the host is not in FIPS mode. Set it to `0` to downgrade that to a startup warning.
 
 ## Deploy
 
-Each Plane Enterprise FIPS release ships a deployment bundle containing the files below. The
-Plane Enterprise source repository is private, so these files are not publicly browsable - they
-are distributed with the release. If you don't have the bundle for your release, request it from
-your Plane account team or [contact support](https://plane.so/contact).
+The FIPS deployment bundle ships with every Plane Enterprise FIPS release:
 
 - `docker-compose-fips.yml` - the FIPS stack
 - `variables.env` - environment template
-- `README-FIPS.md` - the authoritative operations reference
 - `verify-fips.sh` - the verification script (see [Verify](#verify))
 
 ```bash
@@ -120,50 +112,29 @@ non-zero when a check does not hold, so it can gate a deployment pipeline:
 
 ## Configuration defaults specific to FIPS images
 
-The FIPS images default to a stricter security posture than the standard images. Each default is
-overridable with an environment variable, in either direction. These matter mainly if you are
-moving an existing standard deployment onto the FIPS images; a fresh FIPS install needs none of
-them changed.
+The FIPS images default to a stricter security posture than the standard images. A fresh FIPS
+install needs none of these changed; they matter mainly when moving an existing standard
+deployment onto the FIPS images.
 
-| Setting                            | FIPS default        | Standard default | Notes                                                                                                                                                                                      |
-| ---------------------------------- | ------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `LDAP_TLS_REQUIRE_CERT`            | `demand`            | `never`          | Validates the directory server's TLS certificate. See [LDAP](#ldap-certificate-validation).                                                                                                |
-| `SAML_REJECT_DEPRECATED_ALGORITHM` | on                  | off              | Rejects assertions signed with RSA-SHA1. The IdP must sign with SHA-256.                                                                                                                   |
-| `SECRET_ENCRYPTION_V2`             | on                  | off              | Writes at-rest secrets as AES-256-GCM instead of the legacy format. Both formats are always readable.                                                                                      |
-| `USAGE_ID_DIGEST`                  | `sha256` (required) | `md5`            | Digest for Plane AI usage-ledger keys. Under FIPS this is **not** an "either direction" override: a FIPS-mode Postgres refuses `md5()`, so `sha256` is required and `md5` is incompatible. |
-
-### LDAP certificate validation
-
-On the FIPS images, LDAP TLS certificate validation is on by default. For it to succeed, **both** of
-the following must hold:
-
-1. The directory certificate chains to a trusted CA. For a private or self-signed CA, point
-   `LDAP_TLS_CA_CERTFILE` at your CA bundle (PEM).
-2. The certificate's CN/SAN matches the host in `LDAP_SERVER_URI`. An IP address or short hostname
-   that is not in the certificate's SAN fails hostname verification **even with the correct CA
-   bundle** - use the fully qualified name the certificate was issued for.
-
-Setting `LDAP_TLS_REQUIRE_CERT=never` restores the previous behaviour and logs a warning on every
-connection.
+| Setting                            | FIPS default        | Standard default | Notes                                                                                                            |
+| ---------------------------------- | ------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `LDAP_TLS_REQUIRE_CERT`            | `demand`            | `never`          | Validates the LDAP server's TLS certificate. Set to `never` to restore the previous behavior.                    |
+| `SAML_REJECT_DEPRECATED_ALGORITHM` | on                  | off              | Rejects assertions signed with RSA-SHA1. The IdP must sign with SHA-256.                                         |
+| `SECRET_ENCRYPTION_V2`             | on                  | off              | Writes at-rest secrets as AES-256-GCM instead of the legacy format. Both formats are always readable.            |
+| `USAGE_ID_DIGEST`                  | `sha256` (required) | `md5`            | Digest for Plane AI usage-ledger keys. `md5` is incompatible with a FIPS-mode Postgres, so `sha256` is required. |
 
 ## Running under a non-root or arbitrary UID (OpenShift)
 
-The FIPS application images run non-root, and FIPS mode itself requires no privilege. How you set
-the pod security context depends on the platform:
+The FIPS application images run non-root, and FIPS mode itself requires no privilege.
 
-**Plain Kubernetes.** Pin the image's built-in user with `runAsUser: 1000`. If you run under a
-different UID, also set `runAsGroup: 0` and `fsGroup: 0` so that UID keeps write access through the
-images' group-`0`-writable directories.
+**Plain Kubernetes** - set `runAsUser: 1000` (the images' built-in user). For any other UID, add
+`runAsGroup: 0` and `fsGroup: 0`.
 
-**OpenShift (`restricted-v2`).** Do **not** set `runAsUser`, `runAsGroup`, or `fsGroup` yourself. The
-SCC assigns an arbitrary high UID that is a member of group `0`, and it allocates `fsGroup` from the
-namespace's `openshift.io/sa.scc.supplemental-groups` range - an explicit `fsGroup: 0` is rejected
-unless that range includes `0`. No image change or group override is needed: the images' writable
-directories are already group-`0` writable, which is exactly what the assigned UID needs.
-
-The bundled proxy is the one exception: Caddy binds `:80`/`:443`, which `restricted-v2` forbids for a
-non-root process. Front it with an OpenShift Route (running Caddy on high ports), or grant it an SCC
-that permits `NET_BIND_SERVICE`. Ingress-based deployments do not use the bundled proxy.
+**OpenShift (`restricted-v2`)** - works out of the box. Don't set `runAsUser`/`runAsGroup`/`fsGroup`
+yourself; the SCC assigns an arbitrary UID in group `0`, and the images' writable directories are
+group-`0` writable by design. One exception: the bundled proxy binds ports 80/443, which
+`restricted-v2` forbids - front it with an OpenShift Route instead. Ingress-based deployments don't
+use the bundled proxy.
 
 ## Scope of coverage
 

--- a/docs/self-hosting/methods/fips-deployment.md
+++ b/docs/self-hosting/methods/fips-deployment.md
@@ -1,6 +1,6 @@
 ---
 title: FIPS deployment
-description: Deploy the FIPS variant of Plane Enterprise on a FIPS-enforcing host, including prerequisites, image list, verification, and scope of coverage.
+description: Deploy the FIPS variant of Plane Enterprise on a FIPS-enforcing host, including prerequisites, image list, and verification.
 keywords: plane fips, fips 140-3 deployment, plane commercial fips, govcloud plane, federal self-hosting, fips enabled containers
 head:
   - - meta
@@ -210,34 +210,3 @@ yourself; the SCC assigns an arbitrary UID in group `0`, and the images' writabl
 group-`0` writable by design. One exception: the bundled proxy binds ports 80/443, which
 `restricted-v2` forbids - front it with an OpenShift Route instead. Ingress-based deployments don't
 use the bundled proxy.
-
-## Scope of coverage
-
-**Covered.** The Plane application images run their cryptography against FIPS-validated modules on a
-FIPS-enforcing host. Non-approved algorithms are refused.
-
-**The bundled data plane is not FIPS.** The `postgres`, `valkey`, `rabbitmq`, `minio`,
-`opensearch`, and `iframely` services in the stack are upstream third-party images with no
-FIPS-validated cryptography - there are no FIPS variants of them. They are suitable for evaluation
-only. For an accreditable deployment, replace them with externally managed datastores on FIPS
-endpoints and repoint the connection variables:
-
-| Service       | Replace with                          | Variables                                     |
-| ------------- | ------------------------------------- | --------------------------------------------- |
-| `plane-db`    | RDS / Aurora PostgreSQL               | `DATABASE_URL`, `PGHOST`, `POSTGRES_*`        |
-| `plane-redis` | ElastiCache (Valkey/Redis)            | `REDIS_URL`, `REDIS_HOST`, `REDIS_PORT`       |
-| `plane-mq`    | Amazon MQ (RabbitMQ)                  | `AMQP_URL`, `RABBITMQ_*`                      |
-| `plane-minio` | S3 on a FIPS endpoint, or similar     | `AWS_S3_ENDPOINT_URL`, `AWS_*`, `USE_MINIO=0` |
-| `opensearch`  | Amazon OpenSearch Service, or similar | `OPENSEARCH_URL`, `OPENSEARCH_*`              |
-
-Then set the corresponding `*_REPLICAS` to `0`, or remove those services, so the bundled ones do
-not start.
-
-**TLS termination.** The bundled proxy (Caddy) is built against a FIPS-validated module, but for an
-accredited topology the recommended pattern is to terminate TLS at a validated endpoint in front of
-the deployment - such as a FIPS-enabled load balancer - and have the proxy serve HTTP internally.
-
-**FIPS validation applies to the cryptographic modules, not to Plane as a product.** FIPS 140-3
-certificates are held by the module vendors (Red Hat and the Go project). This deployment ensures
-Plane's cryptography _uses_ those validated modules on a compliant host; it does not make Plane
-itself a FIPS-certified product.

--- a/docs/self-hosting/methods/fips-deployment.md
+++ b/docs/self-hosting/methods/fips-deployment.md
@@ -43,7 +43,7 @@ Pin a specific release tag for any accredited deployment rather than tracking `l
 fixed image version is part of the audit trail.
 
 :::info
-There is no FIPS All-in-One (AIO) image. The AIO image is built on an Alpine base, which has no FIPS-validated cryptography, so a FIPS deployment uses the multi-container Compose stack below, not the AIO image.
+There is no FIPS All-in-One (AIO) image. The AIO image is built on an Alpine base, which has no FIPS-validated cryptography, so a FIPS deployment uses the multi-container stack, not the AIO image.
 :::
 
 ## Host prerequisite
@@ -69,26 +69,11 @@ sudo reboot
 
 **Other** - boot a vendor FIPS image (a RHEL FIPS AMI, Ubuntu Pro FIPS), or install OpenShift with FIPS enabled.
 
-As a safeguard, the shipped Compose file sets `PLANE_REQUIRE_FIPS=1`, so the containers **refuse to
-start** if the host is not in FIPS mode. Set it to `0` to downgrade that to a startup warning.
+As a safeguard, run the FIPS images with `PLANE_REQUIRE_FIPS=1`: the containers then **refuse to
+start** if the host is not in FIPS mode. Without it, a FIPS image on a non-FIPS host logs a startup
+warning but runs.
 
-## Deploy
-
-The FIPS deployment bundle ships with every Plane Enterprise FIPS release:
-
-- `docker-compose-fips.yml` - the FIPS stack
-- `variables.env` - environment template
-- `verify-fips.sh` - the verification script (see [Verify](#verify))
-
-```bash
-# 1. Confirm the host is in FIPS mode (above).
-# 2. Prepare the environment file.
-cp variables.env .env
-#    Edit at least: DOMAIN_NAME, WEB_URL, SECRET_KEY, MACHINE_SIGNATURE.
-
-# 3. Bring the stack up.
-docker compose -f docker-compose-fips.yml up -d
-```
+## Verify
 
 Each container logs its posture on startup:
 
@@ -99,15 +84,20 @@ plane: FIPS mode ACTIVE (host kernel reports fips_enabled=1)
 The Go services (monitor, email, proxy) log a corresponding line, for example
 `Go FIPS 140-3 module ACTIVE`.
 
-## Verify
-
-`verify-fips.sh` checks the posture across the running stack - the kernel flag inside each container, that the
-validated OpenSSL provider is loaded and active, that a non-approved digest is refused, that Node's
-`crypto.getFips()` returns 1, and that the Go services report the module. It is designed to exit
-non-zero when a check does not hold, so it can gate a deployment pipeline:
+To check a running container directly:
 
 ```bash
-./verify-fips.sh
+# Kernel flag inherited from the host - must print 1
+docker exec plane-api cat /proc/sys/crypto/fips_enabled
+
+# The FIPS-validated OpenSSL provider must be loaded and "active"
+docker exec plane-api openssl list -providers
+
+# A non-approved digest must be refused - this must FAIL
+docker exec plane-api sh -c 'echo x | openssl md5'
+
+# Node services must report FIPS - must print 1
+docker exec plane-live node -p "require('crypto').getFips()"
 ```
 
 ## Configuration defaults specific to FIPS images
@@ -142,7 +132,7 @@ use the bundled proxy.
 FIPS-enforcing host. Non-approved algorithms are refused.
 
 **The bundled data plane is not FIPS.** The `postgres`, `valkey`, `rabbitmq`, `minio`, and
-`iframely` services in the Compose file are upstream Alpine/musl images with no FIPS-validated
+`iframely` services in the stack are upstream Alpine/musl images with no FIPS-validated
 cryptography - there are no FIPS variants of them. They are suitable for evaluation only. For an
 accreditable deployment, replace them with externally managed datastores on FIPS endpoints and
 repoint the connection variables:

--- a/docs/self-hosting/methods/install-methods-commercial/fips-deployment.md
+++ b/docs/self-hosting/methods/install-methods-commercial/fips-deployment.md
@@ -56,7 +56,9 @@ The host kernel must be booted in FIPS mode. The container inherits this through
 cat /proc/sys/crypto/fips_enabled     # must print 1
 ```
 
-To enable FIPS mode on a RHEL-family host (RHEL, Rocky, Alma, Amazon Linux 2023):
+How you put the host into FIPS mode depends on the distribution and version:
+
+**Amazon Linux 2023, RHEL 8/9 (and Rocky, Alma)** — enable in place, then reboot:
 
 ```bash
 sudo dnf install -y crypto-policies-scripts
@@ -64,9 +66,13 @@ sudo fips-mode-setup --enable
 sudo reboot
 ```
 
-`/boot` must be its own filesystem for this to work — it is on the stock cloud images.
-Alternatively, boot a vendor FIPS image (a RHEL FIPS AMI, Ubuntu Pro FIPS) or use OpenShift with
-FIPS enabled at install time.
+On AL2023 `/boot` lives on the root filesystem, so no separate partition is required. On RHEL/Rocky/Alma with a **separate** `/boot` (or `/boot/efi`) partition, that partition must be mounted so `fips-mode-setup` can update the bootloader.
+
+**RHEL 10** — `fips-mode-setup` has been **removed**, and switching an already-installed system to FIPS mode is **not supported**. FIPS mode must be enabled **at install time** by adding `fips=1` to the kernel command line (or `fips = true` in a RHEL image-builder blueprint). A post-install `update-crypto-policies --set FIPS` is **not** sufficient for FIPS 140 compliance — the only supported path on a non-FIPS install is reinstalling.
+
+**Other** — boot a vendor FIPS image (a RHEL FIPS AMI, Ubuntu Pro FIPS), or install OpenShift with FIPS enabled.
+
+In all cases, the definitive check is the kernel flag above (`/proc/sys/crypto/fips_enabled` = `1`).
 
 As a safeguard, the shipped Compose file sets `PLANE_REQUIRE_FIPS=1`, so the containers **refuse to
 start** if the host is not in FIPS mode. Set it to `0` to downgrade that to a startup warning.
@@ -93,7 +99,7 @@ docker compose -f docker-compose-fips.yml up -d
 
 Each container logs its posture on startup:
 
-```
+```text
 plane: FIPS mode ACTIVE (host kernel reports fips_enabled=1)
 ```
 
@@ -102,10 +108,11 @@ The Go services (monitor, email, proxy) log a corresponding line, for example
 
 ## Verify
 
-`verify-fips.sh` asserts the posture across the running stack — the kernel flag inside each
-container, that the validated OpenSSL provider is loaded and active, that a non-approved digest is
-refused, that Node's `crypto.getFips()` returns 1, and that the Go services report the module. It
-exits non-zero if any assertion fails, so it can gate a deployment pipeline:
+`verify-fips.sh` (shipped in plane-ee under `deployments/cli/commercial/`, alongside the Compose
+file) checks the posture across the running stack — the kernel flag inside each container, that the
+validated OpenSSL provider is loaded and active, that a non-approved digest is refused, that Node's
+`crypto.getFips()` returns 1, and that the Go services report the module. It is designed to exit
+non-zero when a check does not hold, so it can gate a deployment pipeline:
 
 ```bash
 ./verify-fips.sh
@@ -118,12 +125,12 @@ overridable with an environment variable, in either direction. These matter main
 moving an existing standard deployment onto the FIPS images; a fresh FIPS install needs none of
 them changed.
 
-| Setting                            | FIPS default | Standard default | Notes                                                                                                 |
-| ---------------------------------- | ------------ | ---------------- | ----------------------------------------------------------------------------------------------------- |
-| `LDAP_TLS_REQUIRE_CERT`            | `demand`     | `never`          | Validates the directory server's TLS certificate. See [LDAP](#ldap-certificate-validation).           |
-| `SAML_REJECT_DEPRECATED_ALGORITHM` | on           | off              | Rejects assertions signed with RSA-SHA1. The IdP must sign with SHA-256.                              |
-| `SECRET_ENCRYPTION_V2`             | on           | off              | Writes at-rest secrets as AES-256-GCM instead of the legacy format. Both formats are always readable. |
-| `USAGE_ID_DIGEST`                  | `sha256`     | `md5`            | Digest for Plane AI usage-ledger keys. A FIPS-mode Postgres refuses `md5()`.                          |
+| Setting                            | FIPS default        | Standard default | Notes                                                                                                                                                                                      |
+| ---------------------------------- | ------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `LDAP_TLS_REQUIRE_CERT`            | `demand`            | `never`          | Validates the directory server's TLS certificate. See [LDAP](#ldap-certificate-validation).                                                                                                |
+| `SAML_REJECT_DEPRECATED_ALGORITHM` | on                  | off              | Rejects assertions signed with RSA-SHA1. The IdP must sign with SHA-256.                                                                                                                   |
+| `SECRET_ENCRYPTION_V2`             | on                  | off              | Writes at-rest secrets as AES-256-GCM instead of the legacy format. Both formats are always readable.                                                                                      |
+| `USAGE_ID_DIGEST`                  | `sha256` (required) | `md5`            | Digest for Plane AI usage-ledger keys. Under FIPS this is **not** an "either direction" override: a FIPS-mode Postgres refuses `md5()`, so `sha256` is required and `md5` is incompatible. |
 
 ### LDAP certificate validation
 
@@ -141,14 +148,22 @@ connection.
 
 ## Running under a non-root or arbitrary UID (OpenShift)
 
-The FIPS application images run non-root. On plain Kubernetes, set a `securityContext` that pins the
-image's built-in user (uid `1000`); FIPS mode itself requires no privilege. On OpenShift, the
-`restricted-v2` SCC runs each container as an arbitrary high UID that is always a member of group
-`0` — the images' writable directories are group-`0` writable to support exactly this, so no image
-change is needed. Run the pods with `runAsGroup: 0` / `fsGroup: 0` so that arbitrary UID keeps write
-access. The bundled proxy is the one exception: Caddy binds `:80`/`:443`, which `restricted-v2`
-forbids for non-root — front it with an OpenShift Route on high ports, or use a custom SCC that
-grants `NET_BIND_SERVICE`. Ingress-based deployments do not use the bundled proxy.
+The FIPS application images run non-root, and FIPS mode itself requires no privilege. How you set
+the pod security context depends on the platform:
+
+**Plain Kubernetes.** Pin the image's built-in user with `runAsUser: 1000`. If you run under a
+different UID, also set `runAsGroup: 0` and `fsGroup: 0` so that UID keeps write access through the
+images' group-`0`-writable directories.
+
+**OpenShift (`restricted-v2`).** Do **not** set `runAsUser`, `runAsGroup`, or `fsGroup` yourself. The
+SCC assigns an arbitrary high UID that is a member of group `0`, and it allocates `fsGroup` from the
+namespace's `openshift.io/sa.scc.supplemental-groups` range — an explicit `fsGroup: 0` is rejected
+unless that range includes `0`. No image change or group override is needed: the images' writable
+directories are already group-`0` writable, which is exactly what the assigned UID needs.
+
+The bundled proxy is the one exception: Caddy binds `:80`/`:443`, which `restricted-v2` forbids for a
+non-root process. Front it with an OpenShift Route (running Caddy on high ports), or grant it an SCC
+that permits `NET_BIND_SERVICE`. Ingress-based deployments do not use the bundled proxy.
 
 ## Scope of coverage
 

--- a/docs/self-hosting/methods/install-methods-commercial/fips-deployment.md
+++ b/docs/self-hosting/methods/install-methods-commercial/fips-deployment.md
@@ -1,0 +1,189 @@
+---
+title: FIPS-enabled deployment
+description: Deploy the FIPS variant of Plane Enterprise on a FIPS-enforcing host, including prerequisites, image list, verification, and scope of coverage.
+keywords: plane fips, fips 140-3 deployment, plane commercial fips, govcloud plane, federal self-hosting, fips enabled containers
+search: false
+sidebar: false
+head:
+  - - meta
+    - name: robots
+      content: noindex, nofollow
+---
+
+# FIPS-enabled deployment
+
+Plane Enterprise publishes a FIPS variant of every application image alongside the standard set.
+These images are built on Red Hat UBI 10, apply the system-wide FIPS cryptographic policy, and run
+their cryptography against FIPS-validated modules (Red Hat's OpenSSL FIPS provider for the Python
+and static services; the Go FIPS 140-3 module for the Go services). They are intended for
+deployments that must meet FIPS 140-3 expectations, such as US Federal or GovCloud environments.
+
+> **The single most important prerequisite:** FIPS mode is a property of the **host**, not of the
+> image. A FIPS image on a non-FIPS host starts cleanly and looks identical from the inside while
+> providing none of the guarantees. Read [Host prerequisite](#host-prerequisite) first.
+
+## Images
+
+The FIPS images use the same names as the standard `-commercial` images with a `-fips` suffix, in
+the `makeplane` Docker Hub organization:
+
+| Service       | Image                                   |
+| ------------- | --------------------------------------- |
+| Backend / API | `makeplane/backend-commercial-fips`     |
+| Web           | `makeplane/web-commercial-fips`         |
+| Admin         | `makeplane/admin-commercial-fips`       |
+| Space         | `makeplane/space-commercial-fips`       |
+| Live          | `makeplane/live-commercial-fips`        |
+| Silo          | `makeplane/silo-commercial-fips`        |
+| Monitor       | `makeplane/monitor-commercial-fips`     |
+| Email         | `makeplane/email-commercial-fips`       |
+| Plane AI (Pi) | `makeplane/plane-pi-commercial-fips`    |
+| Proxy         | `makeplane/proxy-commercial-fips`       |
+| Flux          | `makeplane/flux-commercial-fips`        |
+| Node runner   | `makeplane/node-runner-commercial-fips` |
+
+Pin a specific release tag for any accredited deployment rather than tracking `latest` — a known,
+fixed image version is part of the audit trail.
+
+> **Note:** there is no FIPS All-in-One (AIO) image. The AIO image is built on an Alpine base, which
+> has no FIPS-validated cryptography, so a FIPS deployment uses the multi-container Compose stack
+> below, not the AIO image.
+
+## Host prerequisite
+
+The host kernel must be booted in FIPS mode. The container inherits this through
+`/proc/sys/crypto/fips_enabled` and **cannot set it itself**. Verify before deploying:
+
+```bash
+cat /proc/sys/crypto/fips_enabled     # must print 1
+```
+
+To enable FIPS mode on a RHEL-family host (RHEL, Rocky, Alma, Amazon Linux 2023):
+
+```bash
+sudo dnf install -y crypto-policies-scripts
+sudo fips-mode-setup --enable
+sudo reboot
+```
+
+`/boot` must be its own filesystem for this to work — it is on the stock cloud images.
+Alternatively, boot a vendor FIPS image (a RHEL FIPS AMI, Ubuntu Pro FIPS) or use OpenShift with
+FIPS enabled at install time.
+
+As a safeguard, the shipped Compose file sets `PLANE_REQUIRE_FIPS=1`, so the containers **refuse to
+start** if the host is not in FIPS mode. Set it to `0` to downgrade that to a startup warning.
+
+## Deploy
+
+The Compose file and its supporting files live in the plane-ee repository under
+`deployments/cli/commercial/`:
+
+- `docker-compose-fips.yml` — the FIPS stack
+- `variables.env` — environment template
+- `README-FIPS.md` — the authoritative operations reference
+- `verify-fips.sh` — the verification script (see [Verify](#verify))
+
+```bash
+# 1. Confirm the host is in FIPS mode (above).
+# 2. Prepare the environment file.
+cp variables.env .env
+#    Edit at least: DOMAIN_NAME, WEB_URL, SECRET_KEY, MACHINE_SIGNATURE.
+
+# 3. Bring the stack up.
+docker compose -f docker-compose-fips.yml up -d
+```
+
+Each container logs its posture on startup:
+
+```
+plane: FIPS mode ACTIVE (host kernel reports fips_enabled=1)
+```
+
+The Go services (monitor, email, proxy) log a corresponding line, for example
+`Go FIPS 140-3 module ACTIVE`.
+
+## Verify
+
+`verify-fips.sh` asserts the posture across the running stack — the kernel flag inside each
+container, that the validated OpenSSL provider is loaded and active, that a non-approved digest is
+refused, that Node's `crypto.getFips()` returns 1, and that the Go services report the module. It
+exits non-zero if any assertion fails, so it can gate a deployment pipeline:
+
+```bash
+./verify-fips.sh
+```
+
+## Configuration defaults specific to FIPS images
+
+The FIPS images default to a stricter security posture than the standard images. Each default is
+overridable with an environment variable, in either direction. These matter mainly if you are
+moving an existing standard deployment onto the FIPS images; a fresh FIPS install needs none of
+them changed.
+
+| Setting                            | FIPS default | Standard default | Notes                                                                                                 |
+| ---------------------------------- | ------------ | ---------------- | ----------------------------------------------------------------------------------------------------- |
+| `LDAP_TLS_REQUIRE_CERT`            | `demand`     | `never`          | Validates the directory server's TLS certificate. See [LDAP](#ldap-certificate-validation).           |
+| `SAML_REJECT_DEPRECATED_ALGORITHM` | on           | off              | Rejects assertions signed with RSA-SHA1. The IdP must sign with SHA-256.                              |
+| `SECRET_ENCRYPTION_V2`             | on           | off              | Writes at-rest secrets as AES-256-GCM instead of the legacy format. Both formats are always readable. |
+| `USAGE_ID_DIGEST`                  | `sha256`     | `md5`            | Digest for Plane AI usage-ledger keys. A FIPS-mode Postgres refuses `md5()`.                          |
+
+### LDAP certificate validation
+
+On the FIPS images, LDAP TLS certificate validation is on by default. For it to succeed, **both** of
+the following must hold:
+
+1. The directory certificate chains to a trusted CA. For a private or self-signed CA, point
+   `LDAP_TLS_CA_CERTFILE` at your CA bundle (PEM).
+2. The certificate's CN/SAN matches the host in `LDAP_SERVER_URI`. An IP address or short hostname
+   that is not in the certificate's SAN fails hostname verification **even with the correct CA
+   bundle** — use the fully qualified name the certificate was issued for.
+
+Setting `LDAP_TLS_REQUIRE_CERT=never` restores the previous behaviour and logs a warning on every
+connection.
+
+## Running under a non-root or arbitrary UID (OpenShift)
+
+The FIPS application images run non-root. On plain Kubernetes, set a `securityContext` that pins the
+image's built-in user (uid `1000`); FIPS mode itself requires no privilege. On OpenShift, the
+`restricted-v2` SCC runs each container as an arbitrary high UID that is always a member of group
+`0` — the images' writable directories are group-`0` writable to support exactly this, so no image
+change is needed. Run the pods with `runAsGroup: 0` / `fsGroup: 0` so that arbitrary UID keeps write
+access. The bundled proxy is the one exception: Caddy binds `:80`/`:443`, which `restricted-v2`
+forbids for non-root — front it with an OpenShift Route on high ports, or use a custom SCC that
+grants `NET_BIND_SERVICE`. Ingress-based deployments do not use the bundled proxy.
+
+## Scope of coverage
+
+**Covered.** The Plane application images run their cryptography against FIPS-validated modules on a
+FIPS-enforcing host. Non-approved algorithms are refused.
+
+**The bundled data plane is not FIPS.** The `postgres`, `valkey`, `rabbitmq`, `minio`, and
+`iframely` services in the Compose file are upstream Alpine/musl images with no FIPS-validated
+cryptography — there are no FIPS variants of them. They are suitable for evaluation only. For an
+accreditable deployment, replace them with externally managed datastores on FIPS endpoints and
+repoint the connection variables:
+
+| Service       | Replace with                      | Variables                                     |
+| ------------- | --------------------------------- | --------------------------------------------- |
+| `plane-db`    | RDS / Aurora PostgreSQL           | `DATABASE_URL`, `PGHOST`, `POSTGRES_*`        |
+| `plane-redis` | ElastiCache (Valkey/Redis)        | `REDIS_URL`, `REDIS_HOST`, `REDIS_PORT`       |
+| `plane-mq`    | Amazon MQ (RabbitMQ)              | `AMQP_URL`, `RABBITMQ_*`                      |
+| `plane-minio` | S3 on a FIPS endpoint, or similar | `AWS_S3_ENDPOINT_URL`, `AWS_*`, `USE_MINIO=0` |
+
+Then set the corresponding `*_REPLICAS` to `0`, or remove those services, so the bundled ones do
+not start.
+
+**TLS termination.** The bundled proxy (Caddy) is built against a FIPS-validated module, but for an
+accredited topology the recommended pattern is to terminate TLS at a validated endpoint in front of
+the deployment — such as a FIPS-enabled load balancer — and have the proxy serve HTTP internally.
+
+**FIPS validation applies to the cryptographic modules, not to Plane as a product.** FIPS 140-3
+certificates are held by the module vendors (Red Hat and the Go project). This deployment ensures
+Plane's cryptography _uses_ those validated modules on a compliant host; it does not make Plane
+itself a FIPS-certified product.
+
+## Reference
+
+The authoritative operations reference — including every environment variable and the migration
+notes for moving a standard deployment onto FIPS images — is `README-FIPS.md`, shipped alongside
+the Compose file in `deployments/cli/commercial/`.

--- a/docs/self-hosting/methods/install-methods-commercial/fips-deployment.md
+++ b/docs/self-hosting/methods/install-methods-commercial/fips-deployment.md
@@ -2,8 +2,6 @@
 title: FIPS-enabled deployment
 description: Deploy the FIPS variant of Plane Enterprise on a FIPS-enforcing host, including prerequisites, image list, verification, and scope of coverage.
 keywords: plane fips, fips 140-3 deployment, plane commercial fips, govcloud plane, federal self-hosting, fips enabled containers
-search: false
-sidebar: false
 head:
   - - meta
     - name: robots


### PR DESCRIPTION
## What

Adds the **FIPS-enabled deployment guide** for the `makeplane/*-commercial-fips` image set, under the Commercial Edition install methods (`self-hosting/methods/install-methods-commercial/fips-deployment.md`).

This **supersedes makeplane/docs#484** — self-hosting content lives on `developers.plane.so`, so the guide belongs in this repo rather than the general docs site. That PR is being closed in favour of this one.

## Placement & conventions

Placed beside the other Commercial Edition install pages (`docker-compose.md`, `kubernetes.md`) and follows their exact convention: `search: false`, `sidebar: false`, `robots: noindex, nofollow`, and added to the `vitepress-plugin-llms` `ignoreFiles` list in `config.mts`. Reached by direct link like its siblings.

## Contents

- **Host prerequisite** — the `fips=1` boot requirement (the single most-missed step: a FIPS image on a non-FIPS host looks fine but provides nothing).
- **Image list** — all 12 `-commercial-fips` images; note there is deliberately no FIPS AIO image (Alpine base has no validated crypto).
- **Deploy + verify** — the `docker-compose-fips.yml` flow and the `verify-fips.sh` posture check.
- **FIPS-only config defaults** — `LDAP_TLS_REQUIRE_CERT`, `SAML_REJECT_DEPRECATED_ALGORITHM`, `SECRET_ENCRYPTION_V2`, `USAGE_ID_DIGEST`, each with its override and standard-image default, plus the LDAP hostname-matching gotcha.
- **Non-root / OpenShift** — running under a pinned uid on k8s and under an arbitrary uid + gid 0 on OpenShift `restricted-v2`, plus the bundled-proxy low-port caveat. (New vs #484 — reflects the validated OpenShift arbitrary-UID work.)
- **Scope of coverage** — honest boundaries: bundled data plane is not FIPS (use managed FIPS-endpoint datastores); TLS-termination recommendation; FIPS 140-3 certification is a property of the modules (Red Hat's, Go's), not of Plane as a product.

Points at `deployments/cli/commercial/README-FIPS.md` in plane-ee as the authoritative operations reference.

## Validation

- `prettier` clean on both files.
- New page's only internal links are anchors to its own headings (no cross-page links).
- Full local VitePress build couldn't run in my working tree due to an unrelated missing dependency (`@voidzero-dev/vitepress-theme`); CI's clean install + build is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for deploying in FIPS-enabled environments.
  - Documented supported images, host prerequisites, distribution setup, Compose, Kubernetes, and OpenShift deployment options.
  - Added instructions for startup checks, verification, security defaults, LDAP certificate validation, and coverage limitations.
  - Clarified requirements for replacing bundled data-plane services with externally managed FIPS endpoints for accredited deployments.
  - Added the FIPS deployment guide to the self-hosting documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->