### PR TITLE
docs: group-sync mapping filter, patch-by-project-key, empty-body 400

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1058,6 +1058,10 @@ export default extendConfig(
                     { text: "Create Project Mapping", link: "/api-reference/idp-group-sync/create-project-mapping" },
                     { text: "Get Project Mapping", link: "/api-reference/idp-group-sync/get-project-mapping" },
                     { text: "Update Project Mapping", link: "/api-reference/idp-group-sync/update-project-mapping" },
+                    {
+                      text: "Update Project Mapping by Key",
+                      link: "/api-reference/idp-group-sync/update-project-mapping-by-key",
+                    },
                     { text: "Delete Project Mapping", link: "/api-reference/idp-group-sync/delete-project-mapping" },
                     {
                       text: "List Workspace Mappings",

--- a/docs/api-reference/idp-group-sync/list-project-mappings.md
+++ b/docs/api-reference/idp-group-sync/list-project-mappings.md
@@ -14,7 +14,7 @@ keywords: plane, plane api, rest api, api integration, idp group sync, list proj
 <div class="api-two-column">
 <div class="api-left">
 
-Retrieve all IdP group → project mappings for the workspace.
+Retrieve all IdP group → project mappings for the workspace. Pass `project_identifier` to return only the mappings for a single project.
 
 <div class="params-section">
 
@@ -25,6 +25,21 @@ Retrieve all IdP group → project mappings for the workspace.
 <ApiParam name="workspace_slug" type="string" :required="true">
 
 The workspace_slug represents the unique workspace identifier for a workspace in Plane. It can be found in the URL. For example, in the URL `https://app.plane.so/my-team/projects/`, the workspace slug is `my-team`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Query Parameters
+
+<div class="params-list">
+
+<ApiParam name="project_identifier" type="string" :required="false">
+
+Filter mappings to a single project by its identifier (e.g. `ENG`). Case-insensitive — the value is matched against the uppercase project identifier. An unknown identifier returns an empty list.
 
 </ApiParam>
 

--- a/docs/api-reference/idp-group-sync/update-project-mapping-by-key.md
+++ b/docs/api-reference/idp-group-sync/update-project-mapping-by-key.md
@@ -1,22 +1,24 @@
 ---
-title: Update project group mapping
-description: Update a project group mapping via Plane API. HTTP request format, parameters, scopes, and example responses for update project group mapping.
-keywords: plane, plane api, rest api, api integration, idp group sync, update project group mapping
+title: Update project group mapping by key
+description: Update a project group mapping by project identifier and IdP group name via Plane API. HTTP request format, parameters, scopes, and example responses.
+keywords: plane, plane api, rest api, api integration, idp group sync, update project group mapping by key
 ---
 
-# Update project group mapping
+# Update project group mapping by key
 
 <div class="api-endpoint-badge">
   <span class="method patch">PATCH</span>
-  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/project-mappings/{mapping_id}/</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/group-sync/project-mappings/{project_key}/{idp_group_name}/</span>
 </div>
 
 <div class="api-two-column">
 <div class="api-left">
 
-Update an existing IdP group → project mapping. Supports partial updates. An empty request body returns `400` with `{"error": "Request body cannot be empty."}`.
+Update an existing IdP group → project mapping addressed by its project identifier and IdP group name instead of the mapping ID. Because a project can have multiple mappings (one per IdP group), both keys are required to identify the target. Supports partial updates.
 
-To address a mapping by its project identifier and IdP group name instead of the mapping ID, see [Update project group mapping by key](/api-reference/idp-group-sync/update-project-mapping-by-key).
+Only project-scoped mappings can be addressed this way. Mappings with `all_projects: true` have no project identifier — update those by mapping ID with [Update project group mapping](/api-reference/idp-group-sync/update-project-mapping).
+
+Returns `404` when no project with the given identifier exists or the project has no mapping for the given IdP group name. An empty request body returns `400` with `{"error": "Request body cannot be empty."}`.
 
 <div class="params-section">
 
@@ -30,9 +32,15 @@ The workspace_slug represents the unique workspace identifier for a workspace in
 
 </ApiParam>
 
-<ApiParam name="mapping_id" type="string" :required="true">
+<ApiParam name="project_key" type="string" :required="true">
 
-The unique identifier of the project group mapping.
+The project identifier (e.g. `ENG`). Case-insensitive — the value is matched against the uppercase project identifier.
+
+</ApiParam>
+
+<ApiParam name="idp_group_name" type="string" :required="true">
+
+The name of the IdP group the mapping belongs to. Matched exactly.
 
 </ApiParam>
 
@@ -84,12 +92,12 @@ When `true`, maps the group to all projects in the workspace. Mutually exclusive
 
 <div class="api-right">
 
-<CodePanel title="Update project group mapping" :languages="['cURL', 'Python', 'JavaScript']">
+<CodePanel title="Update project group mapping by key" :languages="['cURL', 'Python', 'JavaScript']">
 <template #curl>
 
 ```bash
 curl -X PATCH \
-  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/" \
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/ENG/engineering/" \
   -H "X-API-Key: $PLANE_API_KEY" \
   # Or use -H "Authorization: Bearer $PLANE_OAUTH_TOKEN" \
   -H "Content-Type: application/json" \
@@ -105,7 +113,7 @@ curl -X PATCH \
 import requests
 
 response = requests.patch(
-    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/",
+    "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/ENG/engineering/",
     headers={"X-API-Key": "your-api-key"},
     json={"role": "admin"}
 )
@@ -117,7 +125,7 @@ print(response.json())
 
 ```javascript
 const response = await fetch(
-  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/661f9511-f30c-52e5-b827-557766551111/",
+  "https://api.plane.so/api/v1/workspaces/my-workspace/group-sync/project-mappings/ENG/engineering/",
   {
     method: "PATCH",
     headers: {

--- a/docs/api-reference/idp-group-sync/update-workspace-mapping.md
+++ b/docs/api-reference/idp-group-sync/update-workspace-mapping.md
@@ -14,7 +14,7 @@ keywords: plane, plane api, rest api, api integration, idp group sync, update wo
 <div class="api-two-column">
 <div class="api-left">
 
-Update an existing IdP group → workspace role mapping. Supports partial updates.
+Update an existing IdP group → workspace role mapping. Supports partial updates. An empty request body returns `400` with `{"error": "Request body cannot be empty."}`.
 
 <div class="params-section">
 


### PR DESCRIPTION
### Description

Documents the group-sync external API changes shipped in makeplane/plane-ee#8476:

- **List project mappings** — documents the new `project_identifier` query parameter (case-insensitive filter on the project identifier; unknown identifiers return an empty list).
- **New page: Update project group mapping by key** — covers `PATCH /workspaces/{workspace_slug}/group-sync/project-mappings/{project_key}/{idp_group_name}/`, including path/body parameters, scopes, 404 conditions, and the fact that `all_projects: true` mappings cannot be addressed by project key.
- **Empty PATCH bodies** — documents the `400 {"error": "Request body cannot be empty."}` response on the project-mapping and workspace-mapping update endpoints.
- Adds the new page to the IDP Group Sync sidebar in `config.mts`.

Behavior verified against the merged implementation on `plane-ee@preview` (URL patterns, query param normalization, serializer fields, scopes, and error responses).

### Checks

- `pnpm check:format` passes
- `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added API documentation for updating project-scoped identity provider mappings by project key and group name.
  - Documented optional, case-insensitive project filtering when listing mappings.
  - Clarified partial-update behavior and validation errors for empty update requests.
  - Added examples, parameters, supported scopes, error responses, and success payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->