### PR TITLE
docs: sync API v2 reference with fields param and alias removal

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1123,6 +1123,7 @@ export default extendConfig(
                 { text: "Authentication", link: "/api-reference/v2/authentication" },
                 { text: "Pagination", link: "/api-reference/v2/pagination" },
                 { text: "Filtering & Ordering", link: "/api-reference/v2/filtering-and-ordering" },
+                { text: "Sparse Fieldsets", link: "/api-reference/v2/fields" },
                 { text: "Expanding Relations", link: "/api-reference/v2/expanding-relations" },
                 { text: "Errors", link: "/api-reference/v2/errors" },
                 { text: "Migrating from v1", link: "/api-reference/v2/migrating-from-v1" },

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -35,6 +35,7 @@ function updateLayout() {
     "authentication",
     "pagination",
     "filtering-and-ordering",
+    "fields",
     "expanding-relations",
     "errors",
     "work-item-type-modes",

--- a/docs/api-reference/v2/audit-logs/list-audit-logs.md
+++ b/docs/api-reference/v2/audit-logs/list-audit-logs.md
@@ -172,6 +172,24 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count`; 
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `workspaces.audit_logs:read`

--- a/docs/api-reference/v2/cycles/list-cycles.md
+++ b/docs/api-reference/v2/cycles/list-cycles.md
@@ -77,6 +77,13 @@ Free-text search term matched against the cycle.
 
 </ApiParam>
 
+<ApiParam name="name" type="string" :required="false">
+
+Exact cycle name match (case-insensitive). Use it to resolve a human name to a cycle id. There is no path alias
+such as `…/cycles/name:…/`.
+
+</ApiParam>
+
 </div>
 
 **Ordering**
@@ -132,6 +139,31 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count` �
 </div>
 
 <div class="params-section">
+
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+<ApiParam name="expand" type="string" :required="false">
+
+Comma-separated relations to embed alongside the ids. Cycles support `owned_by`. Expansion is separate-key.
+See [Expanding relations](/api-reference/v2/expanding-relations).
+
+</ApiParam>
+
+</div>
+</div>
 
 ### Scopes
 

--- a/docs/api-reference/v2/expanding-relations.md
+++ b/docs/api-reference/v2/expanding-relations.md
@@ -1,60 +1,72 @@
 ---
 title: Expanding relations
 description: How ?expand= works in Plane API v2. Sparse reads, the separate-key expansion contract, which resources support expansion, and the exact shape of each expanded object.
-keywords: plane api v2, expand, sparse fields, state_id, assignee_ids, embedded relations, expand state, expand assignees, expand member
+keywords: plane api v2, expand, sparse fields, state_id, assignee_ids, embedded relations, expand state, expand assignees, expand member, expand cycle
 ---
 
 # Expanding relations
 
 v2 reads are **sparse by default**. A response gives you scalars plus identifiers for everything related to it — never an embedded object tree:
 
-- A to-one relation comes back as **`<name>_id`**: `state_id`, `type_id`, `parent_id`, `created_by_id`.
-- A to-many relation comes back as **`<name>_ids`**, an array: `assignee_ids`, `label_ids`.
+- A to-one relation comes back as **`<name>_id`**: `state_id`, `type_id`, `parent_id`, `created_by_id`, `cycle_id`.
+- A to-many relation comes back as **`<name>_ids`**, an array: `assignee_ids`, `label_ids`, `module_ids`.
 
 `?expand=` opts a single request into richer output for specific relations. It takes a comma-separated list:
 
 ```bash
-GET .../work-items/?expand=state,assignees
+GET .../work-items/?expand=state,assignees,cycle
 ```
+
+Allowed values are **enumerated per operation** in the OpenAPI document. Unknown names are a `400`.
 
 ## Expansion is separate-key
 
 This is the part that trips people up, so it is worth stating flatly:
 
 ::: warning `?expand=` adds a key. It never replaces one.
-`?expand=state` keeps `state_id` exactly where it was **and** adds a separate `state` object beside it. The identifier is not swapped for an object, and it does not disappear. Both are present in the same response.
+`?expand=state` keeps `state_id` exactly where it was **and** adds a separate `state` object beside it. The identifier is not swapped for an object, and it does not disappear. Both are present in the same response (unless you also pass `?fields=` and omit the id — see below).
 :::
 
 Most APIs that offer expansion do the opposite — the `state` key holds a UUID string when you do not expand and an object when you do. That design forces every consumer to write `typeof x === "string" ? x : x.id` at each use site, and it means the shape of your response depends on a query parameter that some other part of your codebase set.
 
 v2 splits the two concerns into two keys with two stable types:
 
-| Key        | Type            | Present when              |
-| ---------- | --------------- | ------------------------- |
-| `state_id` | `string (uuid)` | Always                    |
-| `state`    | object          | Only with `?expand=state` |
+| Key        | Type            | Present when                                      |
+| ---------- | --------------- | ------------------------------------------------- |
+| `state_id` | `string (uuid)` | By default; omit only via explicit `?fields=`     |
+| `state`    | object          | Only with `?expand=state`                         |
 
 ### Why this matters for your client
 
 - **One type per field, forever.** `state_id` is a `string` in every response your code will ever see. You never union a string with an object, and you never write a type guard to tell them apart.
 - **Expansion is additive, so it is safe to change.** A caller can add or drop `?expand=` without invalidating any code that reads `state_id`. Your identifier-keyed caches, join tables, and foreign keys keep working untouched.
 - **Optional, not conditional.** In a typed client, the expanded key is simply optional — `state?: State`. Compare that with a discriminated union of `string | State`, which every consumer has to narrow.
-- **Nothing to reconcile.** Because both keys are present, `item.state.id` and `item.state_id` never disagree.
+- **Nothing to reconcile.** Because both keys are present by default, `item.state.id` and `item.state_id` never disagree.
 
 The practical rule: **read identifiers from `*_id` / `*_ids`, and treat expanded objects purely as a display convenience** that saves you a round trip.
 
+## Orthogonal to `?fields=`
+
+`?fields=` and `?expand=` are separate namespaces. Expand object keys are not field tokens:
+
+```bash
+GET .../work-items/?fields=id,name&expand=state
+# → { "id": "…", "name": "…", "state": { … } }
+```
+
+`state_id` is omitted because it was not requested; `state` is still added by expand. See [Sparse fieldsets](/api-reference/v2/fields).
+
 ## Where `?expand=` is supported
 
-`?expand=` is supported on exactly two resource families. This is the complete list.
+Every expandable resource declares an allowlist. The table covers the resources in this reference; other v2 resources that appear in the OpenAPI document follow the same contract (their expand enums are listed on each operation).
 
-| Resource                                      | Allowed `expand` values                          |
-| --------------------------------------------- | ------------------------------------------------ |
-| **Work items**                                | `state`, `type`, `parent`, `assignees`, `labels` |
-| **Workspace members** and **project members** | `member`                                         |
-
-::: danger Every other v2 resource does not support `?expand=`
-States, labels, cycles, modules, comments, work item types, properties, property options, property contexts, workspace features, audit logs — none of them accept `?expand=`. There is no partial support and no silent ignoring: any value you pass to a resource with no expandable relations is an unknown value, and unknown values are rejected.
-:::
+| Resource                                      | Allowed `expand` values                                              |
+| --------------------------------------------- | -------------------------------------------------------------------- |
+| **Work items**                                | `state`, `type`, `parent`, `assignees`, `labels`, `cycle`, `modules` |
+| **Work item comments**                        | `actor`                                                              |
+| **Workspace members** and **project members** | `member`                                                             |
+| **Cycles**                                    | `owned_by`                                                           |
+| **Modules**                                   | `lead`, `members`                                                    |
 
 Passing a value the resource does not declare returns a `400`:
 
@@ -67,15 +79,13 @@ Passing a value the resource does not declare returns a `400`:
   "status": 400,
   "code": "validation_error",
   "detail": "One or more fields failed validation.",
-  "errors": [{ "field": "expand", "message": "Unknown expand value(s): project." }]
+  "errors": [{ "field": "expand", "message": "Unknown expand value(s): project. Valid expands: assignees, cycle, labels, modules, parent, state, type" }]
 }
 ```
 
 </ResponsePanel>
 
-::: info `?expand=` is not in the published OpenAPI schema
-The API supports `?expand=` on the resources above, but the parameter is currently **absent from the served OpenAPI document** at `/api/v2/schema/`. Generated SDKs and schema-driven request validators will not know about it, and a strict client may strip it. This page is the reference until the schema catches up — the runtime behavior described here is what the API actually does.
-:::
+The OpenAPI document at `/api/v2/schema/` lists the exact enum for each operation, including write echoes that accept expand on the response.
 
 ## Before and after
 
@@ -99,18 +109,20 @@ curl "https://api.plane.so/api/v2/workspaces/my-team/projects/4af68566-94a4-4eb3
       "identifier": "PROJ-118",
       "sequence_id": 118,
       "priority": "high",
+      "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
       "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
       "type_id": null,
       "assignee_ids": ["16c61a3a-512a-48ac-b0be-b6b46fe6f430"],
       "label_ids": [],
+      "cycle_id": null,
+      "module_ids": [],
       "parent_id": null,
       "start_date": null,
       "target_date": "2026-02-02",
       "is_draft": false,
       "archived_at": null,
       "created_at": "2026-01-14T09:22:41.478363Z",
-      "created_by_id": "16c61a3a-512a-48ac-b0be-b6b46fe6f430",
-      "custom_fields": null
+      "created_by_id": "16c61a3a-512a-48ac-b0be-b6b46fe6f430"
     }
   ],
   "next": null,
@@ -121,6 +133,10 @@ curl "https://api.plane.so/api/v2/workspaces/my-team/projects/4af68566-94a4-4eb3
 ```
 
 </ResponsePanel>
+
+::: info No `custom_fields` on list rows
+Work-item `custom_fields` is **detail-only**: the key is absent on collection rows (not `null`). Request it on retrieve. See [Sparse fieldsets](/api-reference/v2/fields#detail-only-fields).
+:::
 
 **Expanded**
 
@@ -140,10 +156,13 @@ curl "https://api.plane.so/api/v2/workspaces/my-team/projects/4af68566-94a4-4eb3
       "identifier": "PROJ-118",
       "sequence_id": 118,
       "priority": "high",
+      "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
       "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
       "type_id": null,
       "assignee_ids": ["16c61a3a-512a-48ac-b0be-b6b46fe6f430"],
       "label_ids": [],
+      "cycle_id": null,
+      "module_ids": [],
       "parent_id": null,
       "start_date": null,
       "target_date": "2026-02-02",
@@ -151,7 +170,6 @@ curl "https://api.plane.so/api/v2/workspaces/my-team/projects/4af68566-94a4-4eb3
       "archived_at": null,
       "created_at": "2026-01-14T09:22:41.478363Z",
       "created_by_id": "16c61a3a-512a-48ac-b0be-b6b46fe6f430",
-      "custom_fields": null,
       "state": {
         "id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
         "name": "In Progress",
@@ -192,6 +210,14 @@ Expanded objects are deliberately minimal projections — enough to render a row
 | `parent`       | `parent`    | `id`, `name`, `sequence_id`                          |
 | `assignees`    | `assignees` | Array of `id`, `display_name`, `avatar_url`, `email` |
 | `labels`       | `labels`    | Array of `id`, `name`, `color`                       |
+| `cycle`        | `cycle`     | `id`, `name` (or `null` when the item has no cycle)  |
+| `modules`      | `modules`   | Array of `id`, `name`                                |
+
+### Work item comments
+
+| `expand` value | Adds key | Shape                                       |
+| -------------- | -------- | ------------------------------------------- |
+| `actor`        | `actor`  | `id`, `display_name`, `avatar_url`, `email` |
 
 ### Members
 
@@ -232,16 +258,25 @@ curl "https://api.plane.so/api/v2/workspaces/my-team/members/?expand=member" \
 
 Here too the identifier survives: `member_id` is the user's id, and `member` is the object.
 
+### Cycles and modules
+
+| Resource | `expand` value | Adds key   | Shape                                                |
+| -------- | -------------- | ---------- | ---------------------------------------------------- |
+| Cycles   | `owned_by`     | `owned_by` | `id`, `display_name`, `avatar_url`, `email`          |
+| Modules  | `lead`         | `lead`     | `id`, `display_name`, `avatar_url`, `email`          |
+| Modules  | `members`      | `members`  | Array of `id`, `display_name`, `avatar_url`, `email` |
+
 ## Behavior notes
 
 - **A to-many expansion is always an array, never `null`.** With `?expand=assignees`, an unassigned work item gets `"assignees": []`.
-- **A to-one expansion follows its id.** If `parent_id` is `null`, `?expand=parent` produces `"parent": null`.
-- **Expansion works on detail routes too**, not only lists — `GET .../work-items/{pk}/?expand=state,labels` behaves the same way.
-- **Expanding a list does not cost a query per row.** The relations are loaded in bulk, so `?expand=assignees` on a 200-row page is one additional query, not 200.
-- **Expansion is read-only.** Writes always take ids (`state_id`, `assignee_ids`); sending a nested object on a `POST` or `PATCH` does not create or link anything.
+- **A to-one expansion follows its id.** If `parent_id` is `null`, `?expand=parent` produces `"parent": null`. Same for `cycle` when `cycle_id` is null.
+- **Expansion works on detail routes and write echoes too**, not only lists — `GET .../work-items/{pk}/?expand=state,labels` and create/update responses behave the same way.
+- **Expanding a list does not cost a query per row.** The relations are loaded in bulk, so `?expand=assignees` on a 200-row page is a small fixed set of additional queries, not 200.
+- **Expansion is read-only.** Writes always take ids (`state_id`, `assignee_ids`) or the work-item write-only human parallels; sending a nested object on a `POST` or `PATCH` does not create or link anything.
 
 ## Related
 
+- [Sparse fieldsets](/api-reference/v2/fields) — trim keys with `?fields=`
 - [Filtering and ordering](/api-reference/v2/filtering-and-ordering) — filter on the same relations with `state_id`, `assignee_id`, and friends
 - [Pagination](/api-reference/v2/pagination) — the envelope that wraps every expanded list
 - [Migrating from v1](/api-reference/v2/migrating-from-v1) — what to do about v1 responses that embedded these objects by default

--- a/docs/api-reference/v2/fields.md
+++ b/docs/api-reference/v2/fields.md
@@ -1,0 +1,162 @@
+---
+title: Sparse fieldsets
+description: How ?fields= works in Plane API v2. Omit semantics, the all token, list deferral, detail-only fields, and how fields compose with expand.
+keywords: plane api v2, fields, sparse fieldsets, omit, all, custom_fields, deferred_on_list, detail_only
+---
+
+# Sparse fieldsets
+
+v2 responses are already sparse by design — relations ship as `*_id` / `*_ids`, not nested trees. **`?fields=`** goes further: it lets you return only the keys you need. Unrequested keys are **omitted** from the JSON (they are not set to `null`).
+
+```bash
+GET .../work-items/?fields=id,name,state_id
+GET .../work-items/?fields=all
+GET .../work-items/                                 # default field set for that response shape
+```
+
+`?fields=` is declared on every operation whose response body is a core read serializer — list, retrieve, create and update echoes, upsert. Bulk write responses and a few bespoke `APIView`s (for example `users/me`) do not accept it. Allowed names are **enumerated per operation** in the OpenAPI document at `/api/v2/schema/`.
+
+## Omit, not null-out
+
+| Request | Result |
+| --- | --- |
+| `?fields=id,name` | Body contains only those keys (plus `id` is always forced when the resource declares one) |
+| No `?fields=` | Default set for the response shape (see [list deferral](#list-deferral)) |
+| `?fields=all` | Every requestable field for that shape |
+
+```bash
+curl "https://api.plane.so/api/v2/workspaces/my-team/projects/4af68566-94a4-4eb3-94aa-50dc9427067b/work-items/?fields=id,name,state_id&per_page=2" \
+  -H "X-Api-Key: $PLANE_API_KEY"
+```
+
+<ResponsePanel status="200">
+
+```json
+{
+  "data": [
+    {
+      "id": "8f4c2b1e-0d3a-4f7b-9c21-6e5a8b7d4f13",
+      "name": "Fix login redirect",
+      "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f"
+    }
+  ],
+  "next": null,
+  "previous": null,
+  "total_count": 1,
+  "pagination": { "style": "offset" }
+}
+```
+
+</ResponsePanel>
+
+Absent means "not requested". `null` still means "this value is null in the database" when the field is included.
+
+## Syntax
+
+- Comma-separated list, same shape as `?expand=`
+- Empty segments are dropped (`?fields=id,,name` ≡ `?fields=id,name`)
+- Leading/trailing whitespace around a token is ignored
+- Token order does not control JSON key order
+
+## The `all` token
+
+`all` is a reserved word in the fields namespace. It means "every requestable field for this response shape".
+
+- On a **collection**, `all` still excludes [detail-only](#detail-only-fields) fields such as work-item `custom_fields`
+- On a **detail / write echo**, `all` is the full read shape, including detail-only fields
+- Mixing is allowed: `?fields=all,name` is valid — once `all` survives validation, the explicit names are redundant
+
+## List deferral
+
+Some resources omit heavy scalars from **collection** rows by default (HTML blobs and similar). Naming a deferred field in `?fields=` pulls it back; `?fields=all` does the same for every deferred field that is still legal on collections.
+
+Single-object responses (retrieve, create/update echo, upsert) never defer — you get the full requestable set unless you pass `?fields=` yourself.
+
+## Detail-only fields
+
+A small set of fields never appear on collection rows and **cannot be requested there**.
+
+Today the only case in the documented surface is work-item **`custom_fields`**:
+
+| Request | Result |
+| --- | --- |
+| `GET …/work-items/` | Each row has **no** `custom_fields` key |
+| `GET …/work-items/?fields=…,custom_fields` | `400` — not available on collections |
+| `GET …/work-items/{pk}/` | `custom_fields` is present (object or empty `{}`) |
+| `GET …/work-items/{pk}/?fields=id,custom_fields` | Sparse detail with only those keys |
+
+Retrieve (by UUID or by `PROJ-123` identifier), create, and update are the places to read custom property values.
+
+## Orthogonal to `?expand=`
+
+`?fields=` and `?expand=` are **separate namespaces**:
+
+- Field tokens are response field names (`state_id`, `name`, `assignee_ids`)
+- Expand tokens are relation names (`state`, `assignees`, `cycle`)
+
+```bash
+GET .../work-items/?fields=id,name&expand=state
+# → { "id": "…", "name": "…", "state": { … } }
+#    state_id is omitted (not requested); state is added by expand
+```
+
+Passing an expand name to `fields` (or a field name to `expand`) is a `400` with a message that points you at the other parameter — it does not auto-expand.
+
+See [Expanding relations](/api-reference/v2/expanding-relations).
+
+## Errors
+
+Unknown field names are a strict `400 validation_error`. The message includes a did-you-mean hint and the valid list for that operation:
+
+<ResponsePanel status="400">
+
+```json
+{
+  "type": "https://api.plane.so/errors/validation_error",
+  "title": "Validation Error",
+  "status": 400,
+  "code": "validation_error",
+  "detail": "One or more fields failed validation.",
+  "errors": [
+    {
+      "field": "fields",
+      "message": "Unknown field(s): titel — did you mean 'name'? Valid fields: all, id, name, identifier, …"
+    }
+  ]
+}
+```
+
+</ResponsePanel>
+
+Validation order when tokens are mixed:
+
+1. Any token not in the resource's field set and not `all` → `400`
+2. On a collection, an explicitly named detail-only field → `400`
+3. If `all` remains → full requestable set for that shape
+
+## Addressing by attribute, not by path alias
+
+Detail path segments address by **stable identifiers only**:
+
+| Key | Example | Where |
+| --- | --- | --- |
+| Workspace slug | `my-team` | Every workspace-scoped path |
+| Project UUID or identifier | `4af68566-…` or `ENG` | Project detail and parent `project_id` segments |
+| Work item UUID | `8f4c2b1e-…` | Project-scoped detail and writes |
+| Work item human key | `PROJ-142` | Workspace-scoped [get by identifier](/api-reference/v2/work-items/get-work-item-by-identifier) and nested parent segments |
+
+There are **no** scheme-prefixed path aliases (`name:…`, `key:…`, `external:…`, and so on). Look up a record by a mutable attribute on the **list** endpoint, then use the id:
+
+```bash
+# resolve a state name → id in one cheap call
+curl "https://api.plane.so/api/v2/workspaces/my-team/projects/ENG/states/?name=In%20Progress&fields=id,name" \
+  -H "X-Api-Key: $PLANE_API_KEY"
+```
+
+Exact identity filters (`?name=`, and where present `?external_id=` / `?external_source=`) return zero, one, or many rows — they never invent a single-object 409. Pair them with `?fields=id` when you only need the id for a later write.
+
+## Related
+
+- [Expanding relations](/api-reference/v2/expanding-relations) — `?expand=` beside sparse ids
+- [Filtering and ordering](/api-reference/v2/filtering-and-ordering) — identity filters on lists
+- [Migrating from v1](/api-reference/v2/migrating-from-v1) — how v1 `?fields=` maps to v2

--- a/docs/api-reference/v2/filtering-and-ordering.md
+++ b/docs/api-reference/v2/filtering-and-ordering.md
@@ -42,6 +42,25 @@ Filter a relation with its **`*_id` parameter**. There is no bare-name form — 
 
 This mirrors how writes work — you set a relation with `state_id`, and you filter on it with `state_id` too. See [Migrating from v1](/api-reference/v2/migrating-from-v1) if you are used to v1's embedded relation objects.
 
+## Identity filters (resolve a name or key)
+
+Detail paths do not accept attribute aliases such as `name:In Progress`. Look up a record by a mutable attribute on the **list** endpoint instead. These filters are exact (case-insensitive for names) and return zero, one, or many rows — they never invent a single-object 409.
+
+| Filter | Typical resources |
+| --- | --- |
+| `?name=` | States, labels, cycles, modules, and other named collections |
+| `?external_id=` / `?external_source=` | Work items, states, labels, cycles, modules, and other importable resources |
+| `?search=` | Partial match — broader than `?name=` |
+
+Pair with `?fields=id` (or `id,name`) when you only need an id for a later write:
+
+```bash
+curl "https://api.plane.so/api/v2/workspaces/my-team/projects/ENG/states/?name=In%20Progress&fields=id,name" \
+  -H "X-Api-Key: $PLANE_API_KEY"
+```
+
+See [Sparse fieldsets](/api-reference/v2/fields#addressing-by-attribute-not-by-path-alias).
+
 ```bash
 # every cycle owned by one person
 curl "https://api.plane.so/api/v2/workspaces/my-team/projects/4af68566-94a4-4eb3-94aa-50dc9427067b/cycles/?owned_by_id=16c61a3a-512a-48ac-b0be-b6b46fe6f430" \

--- a/docs/api-reference/v2/introduction.md
+++ b/docs/api-reference/v2/introduction.md
@@ -94,7 +94,11 @@ If that returns `200`, your key is valid. If it returns `401`, the header name o
   same as sending `null` to clear it.
 - **`DELETE` returns `204`** with an empty body. Deletes are soft.
 - **Writes take ids, not nested objects.** Set a relation with its `*_id` field (`state_id`, `parent_id`, `lead_id`) or
-  its `*_ids` array (`assignee_ids`, `label_ids`).
+  its `*_ids` array (`assignee_ids`, `label_ids`). Work items also accept write-only human-readable parallels
+  (`state`, `type`, `parent`, `assignees`, `labels`, `estimate`) — see
+  [Work items](/api-reference/v2/work-items/overview#writing-send-ids-or-send-names).
+- **Sparse responses with `?fields=`.** Ask for only the keys you need; unrequested keys are omitted. See
+  [Sparse fieldsets](/api-reference/v2/fields).
 - **Audit fields are read-only.** `created_at`, `created_by_id`, and their siblings are set server-side; sending them
   has no effect.
 
@@ -132,13 +136,25 @@ embedded by default, so response size stays predictable no matter how many relat
 }
 ```
 
+Trim further with **`?fields=`** — unrequested keys are omitted from the JSON (not nulled). `?fields=id,name,state_id`
+returns only those keys; `?fields=all` returns every requestable field for that response shape. See
+[Sparse fieldsets](/api-reference/v2/fields).
+
 ### Expansion is separate-key
 
 `?expand=` **adds** an object beside the id — it never replaces it. `?expand=state` gives you `state_id` _and_ a
 `state` object, so code that reads `state_id` keeps working whether or not the caller asked for the expansion.
 
-Only work items and members support `?expand=`. See
-[Expanding relations](/api-reference/v2/expanding-relations) for the allowed values.
+Work items accept `state`, `type`, `parent`, `assignees`, `labels`, `cycle`, and `modules`. Members, cycles, modules,
+and several other resources declare their own expand allowlists. See
+[Expanding relations](/api-reference/v2/expanding-relations).
+
+### Paths address by stable keys
+
+Detail segments use UUIDs (or the three bare human keys: workspace slug, project identifier, work-item `PROJ-123`).
+There are no scheme-prefixed path aliases (`name:…`, `key:…`, `external:…`). Resolve a mutable attribute — a state
+name, a label name, an external id — with a **list** filter such as `?name=` or `?external_id=`, optionally paired with
+`?fields=id`. Parent `project_id` segments accept the project UUID **or** its bare identifier (`ENG`).
 
 ### Errors are RFC 9457
 
@@ -203,6 +219,7 @@ authority for every field, enum, and scope in this reference.
 - [Authentication](/api-reference/v2/authentication) — API keys, OAuth 2.0, and the scope model.
 - [Pagination](/api-reference/v2/pagination) — offset by default, cursor for deep traversal.
 - [Filtering and ordering](/api-reference/v2/filtering-and-ordering) — query parameters on list endpoints.
+- [Sparse fieldsets](/api-reference/v2/fields) — `?fields=` omit semantics and list deferral.
 - [Expanding relations](/api-reference/v2/expanding-relations) — where `?expand=` works and what it accepts.
 - [Errors](/api-reference/v2/errors) — the RFC 9457 problem shape and the full code table.
 - [Migrating from v1](/api-reference/v2/migrating-from-v1) — what changed and how to move.

--- a/docs/api-reference/v2/labels/list-labels.md
+++ b/docs/api-reference/v2/labels/list-labels.md
@@ -79,6 +79,13 @@ A search term matched against the label `name`. Use it to power type-ahead in a 
 
 </ApiParam>
 
+<ApiParam name="name" type="string" :required="false">
+
+Exact label name match (case-insensitive). Use it to resolve a label name to the id you send in `label_ids`.
+There is no path alias such as `…/labels/name:…/`. Pair with `?fields=id,name` for a cheap resolve.
+
+</ApiParam>
+
 </div>
 
 **Ordering**
@@ -135,6 +142,24 @@ Defaults to `true`. Set to `false` to omit `total_count` and skip the count quer
 </div>
 
 <div class="params-section">
+
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
 
 ### Scopes
 

--- a/docs/api-reference/v2/members/list-project-members.md
+++ b/docs/api-reference/v2/members/list-project-members.md
@@ -142,6 +142,24 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count`; 
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `projects.members:read`

--- a/docs/api-reference/v2/members/list-workspace-members.md
+++ b/docs/api-reference/v2/members/list-workspace-members.md
@@ -138,6 +138,24 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count`; 
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `workspaces.members:read`

--- a/docs/api-reference/v2/migrating-from-v1.md
+++ b/docs/api-reference/v2/migrating-from-v1.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating from v1
 description: A practical guide to moving an integration from the Plane REST API v1 to v2. Path and header changes, PATCH-only writes, RFC 9457 errors, sparse reads, the new pagination envelope, renamed fields, and what v2 does not cover yet.
-keywords: plane api v2 migration, v1 to v2, plane rest api upgrade, is_default, description_html, custom_fields, RFC 9457, sparse reads, PATCH only
+keywords: plane api v2 migration, v1 to v2, plane rest api upgrade, is_default, description_html, custom_fields, RFC 9457, sparse reads, fields, PATCH only
 ---
 
 # Migrating from v1
@@ -20,7 +20,7 @@ This page is the checklist for moving a call across.
 | Errors            | Ad-hoc JSON bodies         | RFC 9457 `application/problem+json` with stable `code`      |
 | Relations on read | Embedded objects           | `*_id` / `*_ids`, plus `?expand=` on work items and members |
 | List envelope     | `results` + cursor strings | `data` + `pagination.style`                                 |
-| Sparse fieldsets  | `?fields=`                 | Not needed — reads are already sparse                       |
+| Sparse fieldsets  | `?fields=` (include-style) | `?fields=` with **omit** semantics + `all`; list deferral   |
 
 Unchanged: the base URL (`https://api.plane.so`), the trailing slash on every path, JSON in and out, and the fine-grained OAuth scope names (`projects.work_items:read`, `projects.states:write`, and so on).
 
@@ -103,19 +103,45 @@ To-one relations come back as `<name>_id`; to-many relations as `<name>_ids` arr
 
 Where you genuinely need the object, add `?expand=`. It is **separate-key**: `?expand=state` keeps `state_id` _and_ adds a `state` object beside it, so nothing you already read stops working.
 
-`?expand=` is supported on **work items** (`state`, `type`, `parent`, `assignees`, `labels`) and on **workspace and project members** (`member`). No other v2 resource supports it, and an unknown value is a `400`. Full details in [Expanding relations](/api-reference/v2/expanding-relations).
+Work items accept `state`, `type`, `parent`, `assignees`, `labels`, `cycle`, and `modules`. Members accept `member`. Cycles, modules, comments, and other resources declare their own allowlists. An unknown value is a `400`. Full details in [Expanding relations](/api-reference/v2/expanding-relations).
 
 ::: tip You usually need fewer objects than v1 gave you
 v1 embedded relations whether or not you used them. Before reaching for `?expand=`, check whether the id is all your code actually consumed — for cache keys, joins, and foreign keys it almost always is.
 :::
 
-There is no `?fields=` in v2. Reads are already sparse, so there is nothing to trim.
+### `?fields=` is omit-based
+
+v2 still has `?fields=`, but the semantics differ from a naive "include only" mental model of v1:
+
+- Unrequested keys are **absent**, not `null`
+- `?fields=all` returns every requestable field for that response shape
+- Collection rows may omit heavy or expensive fields by default (list deferral); naming them pulls them back
+- Work-item `custom_fields` is **detail-only** — absent on list rows, and requesting it on a list is a `400`
+
+```bash
+# v2 — only the keys you name (id is always forced when the resource declares one)
+GET /api/v2/.../work-items/?fields=id,name,state_id
+```
+
+See [Sparse fieldsets](/api-reference/v2/fields).
 
 ## 6. Writes take ids
 
 v2 write payloads take identifiers, never nested objects: `state_id`, `parent_id`, `assignee_ids`, `label_ids`, modules' `lead_id`. An id belonging to another project or workspace is a clean `400` — it never silently links to nothing.
 
+Work items additionally accept write-only human-readable parallels (`state`, `type`, `parent`, `assignees`, `labels`, `estimate`) so importers and agents can avoid a lookup round trip. Sending both a parallel and its `*_id` sibling is a `400`. See [Work items](/api-reference/v2/work-items/overview#writing-send-ids-or-send-names).
+
 Audit fields (`created_at`, `created_by_id`, and friends) are read-only. Sending them has no effect.
+
+## 6b. No path aliases for attribute lookup
+
+v2 does **not** accept scheme-prefixed detail segments such as `…/states/name:In%20Progress/`. Detail paths use UUIDs (plus workspace slug, bare project identifier, and work-item `PROJ-123`). Resolve a name or external id on the list endpoint:
+
+```bash
+GET /api/v2/workspaces/my-team/projects/ENG/states/?name=In%20Progress&fields=id
+```
+
+Parent `project_id` path segments accept the project UUID or its bare identifier (`ENG`).
 
 ## 7. The pagination envelope changed
 

--- a/docs/api-reference/v2/modules/list-modules.md
+++ b/docs/api-reference/v2/modules/list-modules.md
@@ -85,6 +85,13 @@ Free-text match on the module name.
 
 </ApiParam>
 
+<ApiParam name="name" type="string" :required="false">
+
+Exact module name match (case-insensitive). Use it to resolve a human name to a module id. There is no path alias
+such as `…/modules/name:…/`.
+
+</ApiParam>
+
 **Ordering**
 
 <ApiParam name="order_by" type="string" :required="false">
@@ -142,6 +149,31 @@ The default `sort_order` is not unique, so it can't back a stable keyset. A bare
 Modules do not support `?expand=` — `lead_id` and `member_ids` are always returned as ids.
 
 <div class="params-section">
+
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+<ApiParam name="expand" type="string" :required="false">
+
+Comma-separated relations to embed alongside the ids. Modules support `lead` and `members`. Expansion is separate-key.
+See [Expanding relations](/api-reference/v2/expanding-relations).
+
+</ApiParam>
+
+</div>
+</div>
 
 ### Scopes
 

--- a/docs/api-reference/v2/states/list-states.md
+++ b/docs/api-reference/v2/states/list-states.md
@@ -79,6 +79,14 @@ A search term matched against the state name.
 
 </ApiParam>
 
+<ApiParam name="name" type="string" :required="false">
+
+Exact state name match (case-insensitive). Use this to resolve a human label to a `state_id` — for example
+`?name=In%20Progress&fields=id,name`. Prefer this over free-text `search` when you want an exact identity lookup.
+There is no path alias such as `…/states/name:…/`.
+
+</ApiParam>
+
 </div>
 </div>
 
@@ -137,6 +145,24 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count`; 
 </div>
 
 <div class="params-section">
+
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
 
 ### Scopes
 

--- a/docs/api-reference/v2/work-item-comments/list-comments.md
+++ b/docs/api-reference/v2/work-item-comments/list-comments.md
@@ -153,6 +153,31 @@ ordering, so check your spelling there because a typo shows up as an unexpected 
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+<ApiParam name="expand" type="string" :required="false">
+
+Comma-separated relations to embed alongside the ids. Comments support `actor`. Expansion is separate-key.
+See [Expanding relations](/api-reference/v2/expanding-relations).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `projects.work_items.comments:read`

--- a/docs/api-reference/v2/work-item-properties/list-work-item-properties.md
+++ b/docs/api-reference/v2/work-item-properties/list-work-item-properties.md
@@ -103,6 +103,24 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count`; 
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `projects.work_item_properties:read`

--- a/docs/api-reference/v2/work-item-property-contexts/list-property-contexts.md
+++ b/docs/api-reference/v2/work-item-property-contexts/list-property-contexts.md
@@ -101,6 +101,24 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count`; 
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `workspaces.work_item_properties:read`

--- a/docs/api-reference/v2/work-item-property-options/list-property-options.md
+++ b/docs/api-reference/v2/work-item-property-options/list-property-options.md
@@ -112,6 +112,24 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count`; 
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `projects.work_item_properties:read`

--- a/docs/api-reference/v2/work-item-type-properties/list-type-properties.md
+++ b/docs/api-reference/v2/work-item-type-properties/list-type-properties.md
@@ -125,6 +125,24 @@ response.
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `projects.work_item_types:read`

--- a/docs/api-reference/v2/work-item-types/list-work-item-types.md
+++ b/docs/api-reference/v2/work-item-types/list-work-item-types.md
@@ -104,6 +104,24 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count`; 
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `projects.work_item_types:read`

--- a/docs/api-reference/v2/work-items/create-work-item.md
+++ b/docs/api-reference/v2/work-items/create-work-item.md
@@ -197,6 +197,31 @@ type's defaults. See [work item properties](/api-reference/v2/work-item-properti
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+<ApiParam name="expand" type="string" :required="false">
+
+Comma-separated relations to embed on the response: `state`, `type`, `parent`, `assignees`, `labels`, `cycle`,
+`modules`. See [Expanding relations](/api-reference/v2/expanding-relations).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `projects.work_items:write`
@@ -296,10 +321,13 @@ const data = await response.json();
   "identifier": "PROJ-142",
   "sequence_id": 142,
   "priority": "high",
+  "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
   "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
   "type_id": null,
   "assignee_ids": ["16c61a3a-512a-48ac-b0be-b6b46fe6f430"],
   "label_ids": [],
+  "cycle_id": null,
+  "module_ids": [],
   "parent_id": null,
   "start_date": null,
   "target_date": "2026-01-20",
@@ -309,6 +337,7 @@ const data = await response.json();
   "created_by_id": "16c61a3a-512a-48ac-b0be-b6b46fe6f430",
   "custom_fields": {}
 }
+
 ```
 
 </ResponsePanel>

--- a/docs/api-reference/v2/work-items/get-work-item-by-identifier.md
+++ b/docs/api-reference/v2/work-items/get-work-item-by-identifier.md
@@ -53,9 +53,17 @@ item as `PROJ-142`. A project identifier is unique within a workspace, which is 
 
 <div class="params-list">
 
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted. `custom_fields` is available here (detail
+response). See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
 <ApiParam name="expand" type="string" :required="false">
 
-Comma-separated relations to embed alongside the ids: `state`, `type`, `parent`, `assignees`, `labels`.
+Comma-separated relations to embed alongside the ids: `state`, `type`, `parent`, `assignees`, `labels`, `cycle`,
+`modules`.
 
 Expansion is separate-key — `?expand=state` keeps `state_id` and adds a `state` object next to it. An unknown value is
 a `400`.
@@ -141,10 +149,13 @@ const data = await response.json();
   "identifier": "PROJ-142",
   "sequence_id": 142,
   "priority": "high",
+  "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
   "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
   "type_id": "2d9d1a97-5c6f-4a1e-9d5b-8c2f7e30b6a4",
   "assignee_ids": ["16c61a3a-512a-48ac-b0be-b6b46fe6f430"],
   "label_ids": ["c1b8f3d6-9a44-4e12-8f7a-2b6d5c9e1a03"],
+  "cycle_id": null,
+  "module_ids": [],
   "parent_id": null,
   "start_date": "2026-01-12",
   "target_date": "2026-01-20",
@@ -164,6 +175,7 @@ const data = await response.json();
     }
   }
 }
+
 ```
 
 </ResponsePanel>

--- a/docs/api-reference/v2/work-items/get-work-item.md
+++ b/docs/api-reference/v2/work-items/get-work-item.md
@@ -35,7 +35,7 @@ The workspace slug. It appears in your Plane URLs — in `https://app.plane.so/m
 
 <ApiParam name="project_id" type="string (uuid)" :required="true">
 
-The project the work item belongs to.
+The project the work item belongs to. Accepts the project UUID or its bare identifier (for example `ENG`).
 
 </ApiParam>
 
@@ -54,9 +54,17 @@ The work item's UUID. This lookup is UUID-only — a `PROJ-142` identifier here 
 
 <div class="params-list">
 
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted. `id` is always included. `all` returns every
+requestable field, including `custom_fields`. See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
 <ApiParam name="expand" type="string" :required="false">
 
-Comma-separated relations to embed alongside the ids: `state`, `type`, `parent`, `assignees`, `labels`.
+Comma-separated relations to embed alongside the ids: `state`, `type`, `parent`, `assignees`, `labels`, `cycle`,
+`modules`.
 
 Expansion is separate-key — `?expand=state` keeps `state_id` and adds a `state` object next to it. An unknown value is
 a `400`.
@@ -147,10 +155,13 @@ const data = await response.json();
   "identifier": "PROJ-142",
   "sequence_id": 142,
   "priority": "high",
+  "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
   "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
   "type_id": "2d9d1a97-5c6f-4a1e-9d5b-8c2f7e30b6a4",
   "assignee_ids": ["16c61a3a-512a-48ac-b0be-b6b46fe6f430"],
   "label_ids": ["c1b8f3d6-9a44-4e12-8f7a-2b6d5c9e1a03"],
+  "cycle_id": null,
+  "module_ids": [],
   "parent_id": null,
   "start_date": "2026-01-12",
   "target_date": "2026-01-20",
@@ -170,6 +181,7 @@ const data = await response.json();
     }
   }
 }
+
 ```
 
 </ResponsePanel>
@@ -183,10 +195,13 @@ const data = await response.json();
   "identifier": "PROJ-142",
   "sequence_id": 142,
   "priority": "high",
+  "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
   "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
   "type_id": "2d9d1a97-5c6f-4a1e-9d5b-8c2f7e30b6a4",
   "assignee_ids": ["16c61a3a-512a-48ac-b0be-b6b46fe6f430"],
   "label_ids": ["c1b8f3d6-9a44-4e12-8f7a-2b6d5c9e1a03"],
+  "cycle_id": null,
+  "module_ids": [],
   "parent_id": null,
   "start_date": "2026-01-12",
   "target_date": "2026-01-20",
@@ -210,6 +225,7 @@ const data = await response.json();
     }
   ]
 }
+
 ```
 
 </ResponsePanel>
@@ -219,7 +235,7 @@ const data = await response.json();
 
 ## What you get here that a list doesn't give you
 
-- **`custom_fields`** — the work item type's custom property values. The list endpoint returns `null` for this field on
+- **`custom_fields`** — the work item type's custom property values. The list endpoint omits this field on
   every row to avoid resolving properties per row; only single-item reads populate it.
 - **Cheaper expansion** — `?expand=` works on both, but expanding one work item is a fixed cost while expanding a full
   page multiplies it.

--- a/docs/api-reference/v2/work-items/list-work-items.md
+++ b/docs/api-reference/v2/work-items/list-work-items.md
@@ -32,9 +32,9 @@ The workspace slug. It appears in your Plane URLs — in `https://app.plane.so/m
 
 </ApiParam>
 
-<ApiParam name="project_id" type="string (uuid)" :required="true">
+<ApiParam name="project_id" type="string" :required="true">
 
-The project to list work items from.
+The project to list work items from. Accepts the project UUID or its bare identifier (for example `ENG`).
 
 </ApiParam>
 
@@ -238,16 +238,29 @@ the returned `next_cursor` as described in [Pagination](/api-reference/v2/pagina
 
 <div class="params-section">
 
-### Expansion
+### Response shaping
 
 <div class="params-list">
 
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included.
+`all` returns every requestable field for a collection row. `custom_fields` is **not** available here — requesting it
+is a `400`. See [Sparse fieldsets](/api-reference/v2/fields).
+
+Allowed values (also enumerated in OpenAPI): `all`, `archived_at`, `assignee_ids`, `created_at`, `created_by_id`,
+`cycle_id`, `id`, `identifier`, `is_draft`, `label_ids`, `module_ids`, `name`, `parent_id`, `priority`, `project_id`,
+`sequence_id`, `start_date`, `state_id`, `target_date`, `type_id`.
+
+</ApiParam>
+
 <ApiParam name="expand" type="string" :required="false">
 
-Comma-separated relations to embed alongside the ids: `state`, `type`, `parent`, `assignees`, `labels`.
+Comma-separated relations to embed alongside the ids: `state`, `type`, `parent`, `assignees`, `labels`, `cycle`,
+`modules`.
 
 Expansion is separate-key — `?expand=state` keeps `state_id` and adds a `state` object next to it. An unknown value is
-a `400`.
+a `400`. See [Expanding relations](/api-reference/v2/expanding-relations).
 
 </ApiParam>
 
@@ -357,18 +370,20 @@ const data = await response.json();
       "identifier": "PROJ-142",
       "sequence_id": 142,
       "priority": "high",
+      "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
       "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
       "type_id": "2d9d1a97-5c6f-4a1e-9d5b-8c2f7e30b6a4",
       "assignee_ids": ["16c61a3a-512a-48ac-b0be-b6b46fe6f430"],
       "label_ids": ["c1b8f3d6-9a44-4e12-8f7a-2b6d5c9e1a03"],
+      "cycle_id": null,
+      "module_ids": [],
       "parent_id": null,
       "start_date": "2026-01-12",
       "target_date": "2026-01-20",
       "is_draft": false,
       "archived_at": null,
       "created_at": "2026-01-14T09:22:41.478363Z",
-      "created_by_id": "16c61a3a-512a-48ac-b0be-b6b46fe6f430",
-      "custom_fields": null
+      "created_by_id": "16c61a3a-512a-48ac-b0be-b6b46fe6f430"
     },
     {
       "id": "3b7d9e40-1c62-4a85-b0f3-9d5c2e6a8471",
@@ -376,18 +391,20 @@ const data = await response.json();
       "identifier": "PROJ-141",
       "sequence_id": 141,
       "priority": "high",
+      "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
       "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
       "type_id": null,
       "assignee_ids": [],
       "label_ids": [],
+      "cycle_id": null,
+      "module_ids": [],
       "parent_id": "a7e51d24-3b98-4c6d-9f10-7d2c8e4b5a61",
       "start_date": null,
       "target_date": null,
       "is_draft": false,
       "archived_at": null,
       "created_at": "2026-01-13T16:04:02.911204Z",
-      "created_by_id": "16c61a3a-512a-48ac-b0be-b6b46fe6f430",
-      "custom_fields": null
+      "created_by_id": "16c61a3a-512a-48ac-b0be-b6b46fe6f430"
     }
   ],
   "next": 50,
@@ -395,6 +412,7 @@ const data = await response.json();
   "total_count": 327,
   "pagination": { "style": "offset" }
 }
+
 ```
 
 </ResponsePanel>
@@ -410,24 +428,27 @@ const data = await response.json();
       "identifier": "PROJ-142",
       "sequence_id": 142,
       "priority": "high",
+      "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
       "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
       "type_id": "2d9d1a97-5c6f-4a1e-9d5b-8c2f7e30b6a4",
       "assignee_ids": ["16c61a3a-512a-48ac-b0be-b6b46fe6f430"],
       "label_ids": ["c1b8f3d6-9a44-4e12-8f7a-2b6d5c9e1a03"],
+      "cycle_id": null,
+      "module_ids": [],
       "parent_id": null,
       "start_date": "2026-01-12",
       "target_date": "2026-01-20",
       "is_draft": false,
       "archived_at": null,
       "created_at": "2026-01-14T09:22:41.478363Z",
-      "created_by_id": "16c61a3a-512a-48ac-b0be-b6b46fe6f430",
-      "custom_fields": null
+      "created_by_id": "16c61a3a-512a-48ac-b0be-b6b46fe6f430"
     }
   ],
   "next_cursor": "b3A9MTcxJmxpbWl0PTUw",
   "has_more": true,
   "pagination": { "style": "cursor" }
 }
+
 ```
 
 </ResponsePanel>
@@ -435,15 +456,16 @@ const data = await response.json();
 </div>
 </div>
 
-## Why `custom_fields` is `null` here
+## Why `custom_fields` is absent here
 
-Custom property values are resolved per work item. Doing that for a full page would mean an extra lookup pass for every
-row, so the list endpoint skips it and returns `custom_fields: null` on every item — deliberately, not because the
-values are missing.
+`custom_fields` is **detail-only**: collection rows omit the key entirely. Resolving custom properties costs one
+lookup pass per work item, so the list path does not pay that cost. Retrieve a work item (or create/update it) to
+read property values. Requesting `?fields=custom_fields` on this endpoint is a `400`.
 
-To read custom property values, fetch the work item on its own:
-[Get a work item](/api-reference/v2/work-items/get-work-item) or
-[Get by identifier](/api-reference/v2/work-items/get-work-item-by-identifier). Both populate `custom_fields`.
+See [Get a work item](/api-reference/v2/work-items/get-work-item),
+[Get by identifier](/api-reference/v2/work-items/get-work-item-by-identifier), and
+[Sparse fieldsets](/api-reference/v2/fields#detail-only-fields).
+
 
 ## Paging through everything
 

--- a/docs/api-reference/v2/work-items/overview.md
+++ b/docs/api-reference/v2/work-items/overview.md
@@ -1,7 +1,7 @@
 ---
 title: Work items overview
-description: The Plane API v2 work item object. Sparse id-based reads, the PROJ-123 identifier, custom fields, human-readable write inputs, expandable relations, and every work item endpoint.
-keywords: plane api v2, work items, issues, tasks, sequence id, identifier, custom fields, expand, priority, archive work item
+description: The Plane API v2 work item object. Sparse id-based reads, ?fields=, the PROJ-123 identifier, custom fields, human-readable write inputs, expandable relations, and every work item endpoint.
+keywords: plane api v2, work items, issues, tasks, sequence id, identifier, custom fields, fields, expand, priority, archive work item
 ---
 
 # Work items overview
@@ -63,9 +63,21 @@ human-readable names you already have, so you rarely need a lookup round trip be
 
   Label ids applied to the work item. Empty array when unlabeled.
 
+- `cycle_id` _string (uuid)_
+
+  The cycle the work item belongs to, or `null`. A work item is in at most one cycle.
+
+- `module_ids` _array of string_
+
+  Module ids the work item belongs to. Empty array when the item is in no modules.
+
 - `parent_id` _string (uuid)_
 
   The parent work item, or `null` for a top-level item. A parent may live in another project of the same workspace.
+
+- `project_id` _string (uuid)_
+
+  The project that owns the work item. Always present on the read shape (including the workspace-scoped list).
 
 - `start_date` _string (date)_
 
@@ -93,13 +105,13 @@ human-readable names you already have, so you rarely need a lookup round trip be
 
 - `custom_fields` _object_
 
-  Values of the work item type's custom properties, keyed by property name. **Populated only on single-item
-  responses** — it is always `null` on the list endpoint. See [Custom fields](#custom-fields).
+  Values of the work item type's custom properties, keyed by property name. **Present only on single-item
+  responses** — collection rows omit the key entirely (`detail_only`). See [Custom fields](#custom-fields).
 
 ::: info The read shape is sparse and fixed
 `description_html`, `external_id`, `external_source`, and `estimate_point_id` are accepted on writes but are **not**
-part of the read shape — they will not come back on any response. There is also no `updated_at`, no `project_id`, and
-no `workspace_id`: you already know the project from the path.
+part of the default read shape — they will not come back on any response. There is also no `updated_at` and no
+`workspace_id`. Trim further with [`?fields=`](/api-reference/v2/fields).
 :::
 
 </div>
@@ -116,8 +128,11 @@ no `workspace_id`: you already know the project from the path.
   "priority": "high",
   "state_id": "f960d3c2-8524-4a41-b8eb-055ce4be2a7f",
   "type_id": "2d9d1a97-5c6f-4a1e-9d5b-8c2f7e30b6a4",
+  "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
   "assignee_ids": ["16c61a3a-512a-48ac-b0be-b6b46fe6f430"],
   "label_ids": ["c1b8f3d6-9a44-4e12-8f7a-2b6d5c9e1a03"],
+  "cycle_id": null,
+  "module_ids": [],
   "parent_id": null,
   "start_date": "2026-01-12",
   "target_date": "2026-01-20",
@@ -172,8 +187,12 @@ Every project-scoped route needs `projects.work_items:read` for `GET` and `proje
 | UUID (`id`)          | `8f4c2b1e-0d3a-4f7b-9c21-6e5a8b7d4f13` | `.../projects/{project_id}/work-items/{pk}/` — reads and writes   |
 | Human (`identifier`) | `PROJ-142`                             | `/api/v2/workspaces/{slug}/work-items/{identifier}/` — reads only |
 
-The two lookups are separate routes on purpose. The UUID route is the canonical surface for everything, including
-writes. The identifier route is workspace-scoped and read-only, and it exists precisely so a caller holding only
+`{project_id}` on parent path segments accepts the project UUID **or** the bare project identifier (`ENG`). There are
+no scheme-prefixed aliases (`name:…`, `external:…`) on detail segments — resolve those with list filters such as
+`?name=` or `?external_id=`.
+
+The two work-item lookups are separate routes on purpose. The UUID route is the canonical surface for everything,
+including writes. The identifier route is workspace-scoped and read-only, and it exists precisely so a caller holding only
 `PROJ-142` — a chat bot, a commit-hook, an LLM agent — can fetch the work item without first discovering which project
 it belongs to.
 
@@ -184,14 +203,13 @@ Each entry carries the property definition `id`, a human-useful `value`, and a `
 underlying record for option and relation properties (`null` for plain scalars). Properties the work item has no value
 for are omitted rather than emitted as `null`.
 
-::: warning `custom_fields` is null on the list endpoint
-Resolving custom properties costs one lookup pass per work item, so the list endpoint deliberately skips it to avoid an
-N+1 across a full page of results. `custom_fields` is populated only on retrieve, retrieve by identifier, create, and
-update. It is `null` on list, and `null` on the archive and unarchive responses too — those return the work item, not
-its property values.
+::: warning `custom_fields` is absent on the list endpoint
+Resolving custom properties costs one lookup pass per work item, so the list endpoint deliberately omits the key
+entirely (`detail_only`). `custom_fields` is populated on retrieve, retrieve by identifier, create, and update.
 
-If you are exporting custom property values for many work items, list to get the ids, then fetch the ones you need
-individually. Do not expect `custom_fields` to arrive from a list call.
+Requesting `?fields=…,custom_fields` on a list is a `400`. If you are exporting custom property values for many work
+items, list to get the ids, then fetch the ones you need individually. See
+[Sparse fieldsets](/api-reference/v2/fields#detail-only-fields).
 :::
 
 The object is empty (`{}`) when the work item is untyped or custom properties are not enabled for the workspace. See
@@ -226,17 +244,30 @@ ambiguous:
 - The human inputs are **write-only**. Responses always come back in the sparse id shape, so `state` never appears in a
   response body — `state_id` does.
 
-## Expanding relations
+## Sparse fieldsets
 
-Work items are one of only two resources that support `?expand=`. The accepted values are `state`, `type`, `parent`,
-`assignees`, and `labels`, comma-separated.
-
-Expansion is **separate-key**: the `*_id` field is always present, and the expanded object is _added_ beside it under
-the bare name. `?expand=state` gives you both `state_id` and a `state` object; it never swaps one for the other, so a
-client that reads ids keeps working when someone adds an expand to the request.
+Trim any read or write-echo response with `?fields=`. Unrequested keys are omitted (not nulled). `id` is always
+included when the resource declares one. `?fields=all` returns every requestable field for that response shape;
+collections still exclude `custom_fields`.
 
 ```bash
-GET .../work-items/?expand=state,assignees
+GET .../work-items/?fields=id,name,state_id,priority
+GET .../work-items/{pk}/?fields=id,name,custom_fields
+```
+
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+## Expanding relations
+
+Work items support `?expand=` with: `state`, `type`, `parent`, `assignees`, `labels`, `cycle`, and `modules`
+(comma-separated).
+
+Expansion is **separate-key**: the `*_id` / `*_ids` field stays present by default, and the expanded object is _added_
+beside it under the bare name. `?expand=state` gives you both `state_id` and a `state` object; it never swaps one for
+the other. `?fields=` can omit the id if you only want the expanded object.
+
+```bash
+GET .../work-items/?expand=state,assignees,cycle
 ```
 
 An unknown expand value is a `400`. Expansion works on the list, both retrieve routes, and the create/update responses.
@@ -262,11 +293,14 @@ it.
   `assignees` → **`assignee_ids`**, `labels` → **`label_ids`**, `created_by` → **`created_by_id`**.
 - Reads no longer return `updated_at`, `updated_by`, `project`, `workspace`, `description_html`,
   `description_stripped`, `description_binary`, `sort_order`, `completed_at`, `estimate_point`, or `module`.
-- **`identifier`** (`PROJ-142`) and **`custom_fields`** are new on the read shape.
+- **`identifier`** (`PROJ-142`), **`cycle_id`**, **`module_ids`**, and **`custom_fields`** are part of the read shape
+  (`custom_fields` is detail-only — absent on list rows).
 - Writes accept human-readable parallels (`state`, `type`, `parent`, `assignees`, `labels`, `estimate`) alongside the
   id fields.
-- `?expand=` is now **separate-key** — it adds an object beside the id instead of replacing the id. The allowed values
-  are `state`, `type`, `parent`, `assignees`, and `labels`; v1's `project` and `module` expansions are gone.
+- `?expand=` is **separate-key** — it adds an object beside the id instead of replacing it. Allowed values:
+  `state`, `type`, `parent`, `assignees`, `labels`, `cycle`, `modules`.
+- `?fields=` trims response keys with omit semantics; pair it with list identity filters (`?name=`) instead of path
+  aliases when resolving human labels to ids.
 - Updates are `PATCH` only. `PUT` returns `405`.
 - Lists return a pagination envelope instead of a bare array, and errors are RFC 9457 `application/problem+json`.
 

--- a/docs/api-reference/v2/work-items/update-work-item.md
+++ b/docs/api-reference/v2/work-items/update-work-item.md
@@ -193,6 +193,31 @@ properties you submit are replaced; untouched properties keep their values and a
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+<ApiParam name="expand" type="string" :required="false">
+
+Comma-separated relations to embed on the response: `state`, `type`, `parent`, `assignees`, `labels`, `cycle`,
+`modules`. See [Expanding relations](/api-reference/v2/expanding-relations).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `projects.work_items:write`
@@ -291,10 +316,13 @@ const data = await response.json();
   "identifier": "PROJ-142",
   "sequence_id": 142,
   "priority": "urgent",
+  "project_id": "4af68566-94a4-4eb3-94aa-50dc9427067b",
   "state_id": "5d2a91b7-64c0-4f38-b9e2-0a3f7c6d8149",
   "type_id": "2d9d1a97-5c6f-4a1e-9d5b-8c2f7e30b6a4",
   "assignee_ids": ["16c61a3a-512a-48ac-b0be-b6b46fe6f430", "9b7f4c53-2d18-4a6e-8c05-1f3e7d9a2b64"],
   "label_ids": ["c1b8f3d6-9a44-4e12-8f7a-2b6d5c9e1a03"],
+  "cycle_id": null,
+  "module_ids": [],
   "parent_id": null,
   "start_date": "2026-01-12",
   "target_date": null,
@@ -314,6 +342,7 @@ const data = await response.json();
     }
   }
 }
+
 ```
 
 </ResponsePanel>

--- a/docs/api-reference/v2/workspace-work-item-properties/list-workspace-work-item-properties.md
+++ b/docs/api-reference/v2/workspace-work-item-properties/list-workspace-work-item-properties.md
@@ -107,6 +107,24 @@ the response.
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `workspaces.work_item_properties:read`

--- a/docs/api-reference/v2/workspace-work-item-property-options/list-workspace-property-options.md
+++ b/docs/api-reference/v2/workspace-work-item-property-options/list-workspace-property-options.md
@@ -109,6 +109,24 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count`; 
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `workspaces.work_item_properties:read`

--- a/docs/api-reference/v2/workspace-work-item-type-properties/list-workspace-type-properties.md
+++ b/docs/api-reference/v2/workspace-work-item-type-properties/list-workspace-type-properties.md
@@ -113,6 +113,24 @@ the response.
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `workspaces.work_item_types:read`

--- a/docs/api-reference/v2/workspace-work-item-types/list-workspace-work-item-types.md
+++ b/docs/api-reference/v2/workspace-work-item-types/list-workspace-work-item-types.md
@@ -102,6 +102,24 @@ Defaults to `true`. Set to `false` to skip the `COUNT(*)` behind `total_count`; 
 
 <div class="params-section">
 
+
+<div class="params-section">
+
+### Response shaping
+
+<div class="params-list">
+
+<ApiParam name="fields" type="string" :required="false">
+
+Comma-separated field names to return. Unrequested keys are omitted (not nulled). `id` is always included when the
+resource declares one. `all` returns every requestable field for this response shape. Unknown names are a `400`.
+See [Sparse fieldsets](/api-reference/v2/fields).
+
+</ApiParam>
+
+</div>
+</div>
+
 ### Scopes
 
 `workspaces.work_item_types:read`


### PR DESCRIPTION
## Summary

Updates the API v2 reference on top of #303 to match the current OpenAPI document in `plane-ee` (`apps/api/plane/api_v2/core/schema/openapi/`).

### What changed

1. **`?fields=` sparse fieldsets** (new)
   - New concept guide: [`/api-reference/v2/fields`](docs/api-reference/v2/fields.md)
   - Omit semantics, `all` token, list deferral, detail-only fields
   - Documented on list/get/create/update pages and wired into the sidebar

2. **Alias removal**
   - Path segments address by stable keys only (UUID + workspace slug, bare project identifier, work-item `PROJ-123`)
   - No scheme-prefixed aliases (`name:…`, `key:…`, `external:…`)
   - Attribute lookup via list identity filters (`?name=`, `?external_id=`) + optional `?fields=id`
   - Documented on filtering guide, migration guide, and states/labels/cycles/modules list pages

3. **`?expand=` accuracy**
   - Work items now: `state`, `type`, `parent`, `assignees`, `labels`, `cycle`, `modules`
   - Also documented for comments (`actor`), cycles (`owned_by`), modules (`lead`, `members`)
   - Removed stale note that expand was absent from OpenAPI

4. **Work item shape fixes**
   - `custom_fields` is **detail-only** (absent on list rows, not `null`)
   - Read shape includes `project_id`, `cycle_id`, `module_ids`
   - Parent `project_id` path segments accept UUID or bare project identifier

### Source of truth

Verified against `apps/api/plane/api_v2/core/schema/openapi/` and the fields-support design in plane-ee.

## Relation to #303

This PR targets the `docs/api-reference-v2` branch so it can be merged into #303 (or cherry-picked). Diff is the single follow-up commit on top of #303.

## Test plan

- [ ] Preview sidebar shows **Sparse Fieldsets** under v2 Concepts
- [ ] `/api-reference/v2/fields` renders with standard doc layout (not wide API layout)
- [ ] Migrating from v1 no longer claims "There is no `?fields=` in v2"
- [ ] Work item list examples omit `custom_fields` key
- [ ] Expand tables list `cycle` / `modules` for work items