### PR TITLE
docs(airgapped): add missing v3.1.0 services and update image list

### DIFF
--- a/docs/self-hosting/methods/airgapped-edition.md
+++ b/docs/self-hosting/methods/airgapped-edition.md
@@ -94,11 +94,38 @@ Consider these alternatives:
      live:
        image: your-registry.io/plane/live-commercial:${APP_RELEASE_VERSION}
 
+     live-exporter:
+       image: your-registry.io/plane/live-commercial:${APP_RELEASE_VERSION}
+
      monitor:
        image: your-registry.io/plane/monitor-commercial:${APP_RELEASE_VERSION}
 
      silo:
        image: your-registry.io/plane/silo-commercial:${APP_RELEASE_VERSION}
+
+     email:
+       image: your-registry.io/plane/email-commercial:${APP_RELEASE_VERSION}
+
+     pi-api:
+       image: your-registry.io/plane/plane-pi-commercial:${APP_RELEASE_VERSION}
+
+     pi-beat:
+       image: your-registry.io/plane/plane-pi-commercial:${APP_RELEASE_VERSION}
+
+     pi-worker:
+       image: your-registry.io/plane/plane-pi-commercial:${APP_RELEASE_VERSION}
+
+     pi-migrator:
+       image: your-registry.io/plane/plane-pi-commercial:${APP_RELEASE_VERSION}
+
+     runner:
+       image: your-registry.io/plane/node-runner-commercial:${APP_RELEASE_VERSION}
+
+     iframely:
+       image: your-registry.io/plane/iframely:v2.5.3
+
+     proxy:
+       image: your-registry.io/plane/proxy-commercial:${APP_RELEASE_VERSION}
    ```
 
    **Infrastructure services** (if using local setup):

--- a/docs/self-hosting/methods/airgapped-edition.md
+++ b/docs/self-hosting/methods/airgapped-edition.md
@@ -85,6 +85,27 @@ Consider these alternatives:
      api:
        image: your-registry.io/plane/backend-commercial:${APP_RELEASE_VERSION}
 
+     worker:
+       image: your-registry.io/plane/backend-commercial:${APP_RELEASE_VERSION}
+
+     beat-worker:
+       image: your-registry.io/plane/backend-commercial:${APP_RELEASE_VERSION}
+
+     migrator:
+       image: your-registry.io/plane/backend-commercial:${APP_RELEASE_VERSION}
+
+     importer-worker:
+       image: your-registry.io/plane/backend-commercial:${APP_RELEASE_VERSION}
+
+     automation-consumer:
+       image: your-registry.io/plane/backend-commercial:${APP_RELEASE_VERSION}
+
+     webhook-consumer:
+       image: your-registry.io/plane/backend-commercial:${APP_RELEASE_VERSION}
+
+     outbox-poller:
+       image: your-registry.io/plane/backend-commercial:${APP_RELEASE_VERSION}
+
      space:
        image: your-registry.io/plane/space-commercial:${APP_RELEASE_VERSION}
 

--- a/docs/self-hosting/methods/clone-docker-images.md
+++ b/docs/self-hosting/methods/clone-docker-images.md
@@ -55,9 +55,12 @@ makeplane/space-commercial:${APP_RELEASE_VERSION}
 makeplane/live-commercial:${APP_RELEASE_VERSION}
 makeplane/monitor-commercial:${APP_RELEASE_VERSION}
 makeplane/backend-commercial:${APP_RELEASE_VERSION}
-makeplane/iframely:v1.2.0
+makeplane/iframely:v2.5.3
 makeplane/silo-commercial:${APP_RELEASE_VERSION}
 makeplane/email-commercial:${APP_RELEASE_VERSION}
+makeplane/plane-pi-commercial:${APP_RELEASE_VERSION}
+makeplane/node-runner-commercial:${APP_RELEASE_VERSION}
+makeplane/proxy-commercial:${APP_RELEASE_VERSION}
 ```
 
 ::: warning
@@ -76,7 +79,7 @@ Set your version and destination registry before copying images.
 
 ```bash
 # Set your Plane version
-export APP_RELEASE_VERSION="v2.6.3"  # Replace with your desired version
+export APP_RELEASE_VERSION="v3.1.0"  # Replace with your desired version
 
 # Set your destination registry
 export DESTINATION_REGISTRY="your-registry.io/your-namespace"
@@ -188,7 +191,7 @@ Create a file named `copy-plane-images.sh`:
 set -e
 
 # Configuration
-APP_RELEASE_VERSION="${APP_RELEASE_VERSION:-v2.6.3}"
+APP_RELEASE_VERSION="${APP_RELEASE_VERSION:-v3.1.0}"
 DESTINATION_REGISTRY="${DESTINATION_REGISTRY}"
 
 if [ -z "$DESTINATION_REGISTRY" ]; then
@@ -208,9 +211,12 @@ declare -a IMAGES=(
     "live-commercial:${APP_RELEASE_VERSION}"
     "monitor-commercial:${APP_RELEASE_VERSION}"
     "backend-commercial:${APP_RELEASE_VERSION}"
-    "iframely:v1.2.0"
+    "iframely:v2.5.3"
     "silo-commercial:${APP_RELEASE_VERSION}"
     "email-commercial:${APP_RELEASE_VERSION}"
+    "plane-pi-commercial:${APP_RELEASE_VERSION}"
+    "node-runner-commercial:${APP_RELEASE_VERSION}"
+    "proxy-commercial:${APP_RELEASE_VERSION}"
 )
 
 echo "Starting image copy process..."


### PR DESCRIPTION
## Summary

- Add `plane-pi-commercial`, `node-runner-commercial`, `proxy-commercial`, and `live-exporter` to the airgapped image clone list (`clone-docker-images.md`) and compose reference (`airgapped-edition.md`)
- Update `iframely` image version from `v1.2.0` to `v2.5.3`
- Bump default `APP_RELEASE_VERSION` to `v3.1.0` in the clone script and example

## Test plan

- [ ] Verify all services in `docker-compose-airgapped.yml` for v3.1.0 are covered in the image list
- [ ] Confirm iframely version matches compose file (`v2.5.3`)
- [ ] Check that the bash script array includes all new images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated air-gapped deployment examples with private-registry images for additional services.
  * Updated Docker image cloning guidance with the latest image versions and expanded service coverage.
  * Updated example release configuration to version 3.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->