### PR TITLE
docs: match token settings labels to the app UI

### DIFF
--- a/docs/dev-tools/mcp-server.md
+++ b/docs/dev-tools/mcp-server.md
@@ -101,8 +101,8 @@ header; update existing configs.
 
 #### Get a token
 
-Create a personal access token under **Profile settings → Personal access tokens** and copy it when shown. For
-automations, you can instead create a workspace access token under **Workspace settings → Access tokens**.
+Create a personal access token under **Profile Settings → Personal Access Tokens** and copy it when shown. For
+automations, you can instead create a workspace access token under **Workspace Settings → Access Tokens**.
 
 #### Find your workspace slug
 


### PR DESCRIPTION
Follow-up to #313: the MCP server guide named the token pages **Profile settings → Personal access tokens** / **Workspace settings → Access tokens**. The app labels are **Personal Access Tokens** and **Access Tokens**, so this matches the casing (and keeps it consistent with makeplane/docs#489).