### PR TITLE
fix(airgapped): correct infrastructure service names to match compose

### DIFF
--- a/docs/self-hosting/methods/airgapped-edition.md
+++ b/docs/self-hosting/methods/airgapped-edition.md
@@ -73,6 +73,7 @@ Consider these alternatives:
    export DOMAIN_NAME=plane.yourcompany.com
    export WEB_URL=https://plane.yourcompany.com
    export CORS_ALLOWED_ORIGINS=https://plane.yourcompany.com
+   export SITE_ADDRESS=https://plane.yourcompany.com
    ```
 
    **Update image references** in `docker-compose.yml` to point to your private registry:
@@ -153,16 +154,19 @@ Consider these alternatives:
 
    ```yaml
    services:
-     redis:
+     plane-redis:
        image: valkey/valkey:7.2.11-alpine
 
-     postgres:
+     plane-db:
        image: postgres:15.7-alpine
 
-     rabbitmq:
+     pi-db-init:
+       image: postgres:15.7-alpine
+
+     plane-mq:
        image: rabbitmq:3.13.6-management-alpine
 
-     minio:
+     plane-minio:
        image: minio/minio:latest
    ```
 


### PR DESCRIPTION
Rename redis→plane-redis, postgres→plane-db, rabbitmq→plane-mq, minio→plane-minio in the local infrastructure YAML example so they match the actual service names in docker-compose-airgapped.yml. Also add pi-db-init which reuses the postgres image.

### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
