### PR TITLE
fix(airgapped): use plain KEY=VALUE format in plane.env example

### DIFF
--- a/docs/self-hosting/methods/airgapped-edition.md
+++ b/docs/self-hosting/methods/airgapped-edition.md
@@ -66,15 +66,23 @@ Consider these alternatives:
    Edit the `plane.env` file to configure your deployment:
 
    ```bash
-   # Generate a unique machine signature
-   export MACHINE_SIGNATURE=$(uuidgen)
-
    # Set your domain
-   export DOMAIN_NAME=plane.yourcompany.com
-   export WEB_URL=https://plane.yourcompany.com
-   export CORS_ALLOWED_ORIGINS=https://plane.yourcompany.com
-   export SITE_ADDRESS=https://plane.yourcompany.com
+   DOMAIN_NAME=plane.yourcompany.com
+   WEB_URL=https://plane.yourcompany.com
+   CORS_ALLOWED_ORIGINS=https://plane.yourcompany.com
+   SITE_ADDRESS=https://plane.yourcompany.com
+
+   # Paste the generated UUID here (see note below)
+   MACHINE_SIGNATURE=your-uuid-here
    ```
+
+   :::info
+   **Generating `MACHINE_SIGNATURE`:** Run the following command in your terminal to generate a unique UUID, then paste the output as the value of `MACHINE_SIGNATURE` in `plane.env`:
+
+   ```bash
+   uuidgen
+   ```
+   :::
 
    **Update image references** in `docker-compose.yml` to point to your private registry:
 

--- a/docs/self-hosting/methods/airgapped-edition.md
+++ b/docs/self-hosting/methods/airgapped-edition.md
@@ -82,6 +82,7 @@ Consider these alternatives:
    ```bash
    uuidgen
    ```
+
    :::
 
    **Update image references** in `docker-compose.yml` to point to your private registry:


### PR DESCRIPTION
## Summary

- Replace `export KEY=value` syntax with plain `KEY=value` in the `plane.env` configuration example — `docker compose --env-file` does not support shell `export` syntax
- Add a note instructing users to run `uuidgen` in their terminal and paste the output as the value of `MACHINE_SIGNATURE` in `plane.env`

## Test plan

- [ ] Verify env snippet uses plain `KEY=VALUE` format throughout
- [ ] Confirm the `uuidgen` note is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated air-gapped deployment instructions to configure settings directly in `plane.env`.
  * Clarified how to generate and provide the required machine signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->