### PR TITLE
docs: point to documentation monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,17 @@
 # Plane Developer Documentation
 
-Official developer documentation for [Plane](https://plane.so) - an open-source project management platform.
+> [!IMPORTANT]
+> This repository is no longer maintained. Plane's developer documentation has moved to the
+> [Plane documentation monorepo](https://github.com/makeplane/docs).
 
-This repository contains comprehensive guides for REST API integration, self-hosting deployments, and building custom applications on the Plane platform.
+The source now lives in
+[`apps/developer-docs`](https://github.com/makeplane/docs/tree/master/apps/developer-docs), alongside Plane's
+product documentation and shared documentation theme. This repository's complete commit history was imported into
+the monorepo.
 
-## Documentation Sections
+- **Read the documentation:** [developers.plane.so](https://developers.plane.so)
+- **Contribute:** [Contribution guide](https://github.com/makeplane/docs/blob/master/CONTRIBUTING.md)
+- **Report an issue:** [makeplane/docs issues](https://github.com/makeplane/docs/issues)
 
-- **[Self-Hosting](https://developers.plane.so/self-hosting/overview)** - Deploy Plane on your own infrastructure with Docker, Kubernetes, or other platforms
-- **[API Reference](https://developers.plane.so/api-reference/introduction)** - Complete REST API documentation for integrating with Plane
-- **[Developer Tools](https://developers.plane.so/dev-tools/build-plane-app)** - Build custom apps, webhooks, and extensions
-
-## Tech Stack
-
-- [VitePress](https://vitepress.dev/) - Static site generator
-- [Vue 3](https://vuejs.org/) - Custom components
-- [Tailwind CSS](https://tailwindcss.com/) - Styling
-
-## Local Development
-
-### Prerequisites
-
-- Node.js 18+
-- pnpm
-
-### Setup
-
-```bash
-# Install dependencies
-pnpm install
-
-# Start development server
-pnpm dev
-
-# Build for production
-pnpm build
-
-# Preview production build
-pnpm preview
-```
-
-The development server runs at `http://localhost:5173` with hot reload enabled.
-
-## Project Structure
-
-```
-docs/
-├── .vitepress/
-│   ├── config.mts          # VitePress configuration
-│   ├── theme/              # Custom Vue theme
-│   │   ├── components/     # Custom Vue components
-│   │   ├── styles.css           # VoidZero/Vitest theme styles
-│   │   └── plane-overrides.css  # Plane-specific overrides
-│   └── public/             # Static assets (images, logos)
-├── api-reference/          # REST API documentation
-├── self-hosting/           # Deployment and configuration guides
-├── dev-tools/              # Developer tools and extensions
-└── plane-one/              # Plane One (licensed edition) docs
-```
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing to this documentation.
-
-## Community
-
-- [GitHub](https://github.com/makeplane/plane) - Main Plane repository
-- [Discord](https://discord.com/invite/A92xrEGCge) - Community chat
-- [Twitter](https://twitter.com/planepowers) - Updates and announcements
-
-## License
-
-This project is licensed under the [Apache License 2.0](LICENSE).
+This repository remains available as a historical archive and will no longer receive updates. Please open all future
+issues and pull requests in [`makeplane/docs`](https://github.com/makeplane/docs).


### PR DESCRIPTION
## Summary

- replace the obsolete project README with a clear archive notice
- direct source changes and contributions to `makeplane/docs/apps/developer-docs`
- retain links to the live developer documentation and the new issue tracker
- note that the repository history was imported into the monorepo

## Verification

- `pnpm check:format`
- verified the live documentation, migrated source, and contribution guide links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a maintenance notice.
  * Directed readers to the current documentation, contribution guidelines, and issue reporting resources.
  * Clarified that this repository is a historical archive and will no longer receive updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->