### PR TITLE
WIKI-1068: document page and collection APIs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -762,12 +762,85 @@ export default extendConfig(
                   collapsed: true,
                   items: [
                     { text: "Overview", link: "/api-reference/page/overview" },
+                    { text: "Page Content HTML", link: "/api-reference/page/page-content-html" },
                     { text: "List Workspace Pages", link: "/api-reference/page/list-workspace-pages" },
                     { text: "Add Workspace Page", link: "/api-reference/page/add-workspace-page" },
+                    { text: "Get Workspace Page", link: "/api-reference/page/get-workspace-page" },
+                    { text: "Update Workspace Page", link: "/api-reference/page/update-workspace-page" },
+                    { text: "Archive Workspace Page", link: "/api-reference/page/archive-workspace-page" },
+                    { text: "Restore Workspace Page", link: "/api-reference/page/restore-workspace-page" },
+                    { text: "Delete Workspace Page", link: "/api-reference/page/delete-workspace-page" },
+                    {
+                      text: "Get Workspace Page Attachment",
+                      link: "/api-reference/page/get-workspace-page-attachment",
+                    },
+                    {
+                      text: "Confirm Workspace Page Attachment Upload",
+                      link: "/api-reference/page/confirm-workspace-page-attachment-upload",
+                    },
+                    {
+                      text: "Download Workspace Page Attachment",
+                      link: "/api-reference/page/download-workspace-page-attachment",
+                    },
+                    {
+                      text: "Delete Workspace Page Attachment",
+                      link: "/api-reference/page/delete-workspace-page-attachment",
+                    },
                     { text: "List Project Pages", link: "/api-reference/page/list-project-pages" },
                     { text: "Add Project Page", link: "/api-reference/page/add-project-page" },
-                    { text: "Get Workspace Page", link: "/api-reference/page/get-workspace-page" },
                     { text: "Get Project Page", link: "/api-reference/page/get-project-page" },
+                    { text: "Update Project Page", link: "/api-reference/page/update-project-page" },
+                    { text: "Archive Project Page", link: "/api-reference/page/archive-project-page" },
+                    { text: "Restore Project Page", link: "/api-reference/page/restore-project-page" },
+                    { text: "Delete Project Page", link: "/api-reference/page/delete-project-page" },
+                  ],
+                },
+                {
+                  text: "Collections",
+                  collapsed: true,
+                  items: [
+                    { text: "Overview", link: "/api-reference/collection/overview" },
+                    { text: "List Collections", link: "/api-reference/collection/list-collections" },
+                    { text: "Create Collection", link: "/api-reference/collection/create-collection" },
+                    { text: "Retrieve Collection", link: "/api-reference/collection/retrieve-collection" },
+                    { text: "Update Collection", link: "/api-reference/collection/update-collection" },
+                    { text: "Delete Collection", link: "/api-reference/collection/delete-collection" },
+                    {
+                      text: "List Collection Members",
+                      link: "/api-reference/collection/list-collection-members",
+                    },
+                    {
+                      text: "Add Collection Member",
+                      link: "/api-reference/collection/add-collection-member",
+                    },
+                    {
+                      text: "Update Collection Member",
+                      link: "/api-reference/collection/update-collection-member",
+                    },
+                    {
+                      text: "Remove Collection Member",
+                      link: "/api-reference/collection/remove-collection-member",
+                    },
+                    {
+                      text: "List Collection Pages",
+                      link: "/api-reference/collection/list-collection-pages",
+                    },
+                    {
+                      text: "Search Collection Pages",
+                      link: "/api-reference/collection/search-collection-pages",
+                    },
+                    {
+                      text: "Add Collection Pages",
+                      link: "/api-reference/collection/add-collection-pages",
+                    },
+                    {
+                      text: "Move or Reorder Collection Page",
+                      link: "/api-reference/collection/move-or-reorder-collection-page",
+                    },
+                    {
+                      text: "Remove Collection Page",
+                      link: "/api-reference/collection/remove-collection-page",
+                    },
                   ],
                 },
                 {

--- a/docs/api-reference/assets/create-workspace-asset-upload.md
+++ b/docs/api-reference/assets/create-workspace-asset-upload.md
@@ -70,7 +70,7 @@ Asset context. Use `PAGE_DESCRIPTION` for a workspace page attachment.
 
 <ApiParam name="entity_identifier" type="string" :required="false">
 
-UUID of the workspace page when `entity_type` is `PAGE_DESCRIPTION`.
+UUID of the workspace page. This value is required when `entity_type` is `PAGE_DESCRIPTION`.
 
 </ApiParam>
 

--- a/docs/api-reference/assets/create-workspace-asset-upload.md
+++ b/docs/api-reference/assets/create-workspace-asset-upload.md
@@ -14,7 +14,8 @@ keywords: plane, plane api, rest api, api integration, assets, create workspace 
 <div class="api-two-column">
 <div class="api-left">
 
-Generate presigned URL for generic asset upload
+Generate a presigned URL for a workspace asset upload. To attach a file to a workspace page, set `entity_type` to
+`PAGE_DESCRIPTION` and pass the page UUID as `entity_identifier`. The page must be editable, unlocked, and active.
 
 <div class="params-section">
 
@@ -61,6 +62,18 @@ UUID of the project to associate with the asset
 
 </ApiParam>
 
+<ApiParam name="entity_type" type="string" :required="false">
+
+Asset context. Use `PAGE_DESCRIPTION` for a workspace page attachment.
+
+</ApiParam>
+
+<ApiParam name="entity_identifier" type="string" :required="false">
+
+UUID of the workspace page when `entity_type` is `PAGE_DESCRIPTION`.
+
+</ApiParam>
+
 <ApiParam name="external_id" type="string" :required="false">
 
 External identifier for the asset (for integration tracking)
@@ -101,7 +114,8 @@ curl -X POST \
   "name": "Example Name",
   "type": "image/jpeg",
   "size": 1024000,
-  "project_id": "550e8400-e29b-41d4-a716-446655440000",
+  "entity_type": "PAGE_DESCRIPTION",
+  "entity_identifier": "4d2f6f7e-9b4a-4d6a-8f4a-1c3f7c0f4a10",
   "external_id": "550e8400-e29b-41d4-a716-446655440000",
   "external_source": "github"
 }'
@@ -120,7 +134,8 @@ response = requests.post(
       "name": "Example Name",
       "type": "image/jpeg",
       "size": 1024000,
-      "project_id": "550e8400-e29b-41d4-a716-446655440000",
+      "entity_type": "PAGE_DESCRIPTION",
+      "entity_identifier": "4d2f6f7e-9b4a-4d6a-8f4a-1c3f7c0f4a10",
       "external_id": "550e8400-e29b-41d4-a716-446655440000",
       "external_source": "github"
     }
@@ -142,7 +157,8 @@ const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspac
     name: "Example Name",
     type: "image/jpeg",
     size: 1024000,
-    project_id: "550e8400-e29b-41d4-a716-446655440000",
+    entity_type: "PAGE_DESCRIPTION",
+    entity_identifier: "4d2f6f7e-9b4a-4d6a-8f4a-1c3f7c0f4a10",
     external_id: "550e8400-e29b-41d4-a716-446655440000",
     external_source: "github",
   }),
@@ -158,7 +174,7 @@ const data = await response.json();
 ```json
 {
   "asset_id": "550e8400-e29b-41d4-a716-446655440000",
-  "asset_url": "/api/assets/v2/workspaces/my-workspace/projects/None/issues/None/attachments/550e8400-e29b-41d4-a716-446655440000/",
+  "asset_url": "/api/v1/workspaces/my-workspace/pages/4d2f6f7e-9b4a-4d6a-8f4a-1c3f7c0f4a10/attachments/550e8400-e29b-41d4-a716-446655440000/",
   "upload_data": {
     "url": "https://uploads.example.com/plane-bucket",
     "fields": {

--- a/docs/api-reference/assets/create-workspace-asset-upload.md
+++ b/docs/api-reference/assets/create-workspace-asset-upload.md
@@ -148,10 +148,11 @@ print(response.json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/assets/", {
   method: "POST",
   headers: {
-    "X-API-Key": "your-api-key",
+    "X-API-Key": process.env.PLANE_API_KEY,
     "Content-Type": "application/json",
   },
   body: JSON.stringify({

--- a/docs/api-reference/assets/create-workspace-asset-upload.md
+++ b/docs/api-reference/assets/create-workspace-asset-upload.md
@@ -64,13 +64,14 @@ UUID of the project to associate with the asset
 
 <ApiParam name="entity_type" type="string" :required="false">
 
-Asset context. Use `PAGE_DESCRIPTION` for a workspace page attachment.
+Asset context. Use `PAGE_DESCRIPTION` for a workspace page attachment; when you do, `entity_identifier` is also
+required.
 
 </ApiParam>
 
 <ApiParam name="entity_identifier" type="string" :required="false">
 
-UUID of the workspace page. This value is required when `entity_type` is `PAGE_DESCRIPTION`.
+UUID of the workspace page. This value and `entity_type` are required together for a `PAGE_DESCRIPTION` attachment.
 
 </ApiParam>
 

--- a/docs/api-reference/collection/add-collection-member.md
+++ b/docs/api-reference/collection/add-collection-member.md
@@ -1,0 +1,76 @@
+---
+title: Add a collection member
+description: Grant a workspace user access to a private Plane collection.
+keywords: plane, plane api, rest api, collection members, add member, private collection
+---
+
+# Add a collection member
+
+<div class="api-endpoint-badge"><span class="method post">POST</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Adds an explicit member to a private collection. The caller must be able to manage the collection.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+
+### Body Parameters
+
+<ApiParam name="member" type="uuid" :required="true">The workspace user's ID.</ApiParam>
+<ApiParam name="access" type="integer" :required="false">`0` (view, default), `1` (comment), or `2` (edit).</ApiParam>
+
+### OAuth scope
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Add a collection member" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/" \
+  -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" \
+  -d '{"member":"6f356c85-bb22-47e0-b8b1-cf18aa6adad3","access":0}'
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/"
+response = requests.post(url, headers={"X-API-Key": "your-api-key"}, json={"member": "6f356c85-bb22-47e0-b8b1-cf18aa6adad3", "access": 0})
+print(response.json())
+```
+
+</template><template #javascript>
+
+```javascript
+const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/";
+const response = await fetch(url, {
+  method: "POST",
+  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  body: JSON.stringify({ member: "6f356c85-bb22-47e0-b8b1-cf18aa6adad3", access: 0 }),
+});
+console.log(await response.json());
+```
+
+</template></CodePanel>
+<ResponsePanel status="201">
+
+```json
+{
+  "id": "4edec253-26f4-4667-8f52-9488dca1c620",
+  "collection": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+  "member": "6f356c85-bb22-47e0-b8b1-cf18aa6adad3",
+  "access": 0,
+  "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+  "created_at": "2026-08-18T10:00:00Z",
+  "updated_at": "2026-08-18T10:00:00Z",
+  "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f"
+}
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/add-collection-member.md
+++ b/docs/api-reference/collection/add-collection-member.md
@@ -90,10 +90,11 @@ print(response.json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/";
 const response = await fetch(url, {
   method: "POST",
-  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY, "Content-Type": "application/json" },
   body: JSON.stringify({ member: "6f356c85-bb22-47e0-b8b1-cf18aa6adad3", access: 0 }),
 });
 console.log(await response.json());

--- a/docs/api-reference/collection/add-collection-member.md
+++ b/docs/api-reference/collection/add-collection-member.md
@@ -6,28 +6,69 @@ keywords: plane, plane api, rest api, collection members, add member, private co
 
 # Add a collection member
 
-<div class="api-endpoint-badge"><span class="method post">POST</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method post">POST</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Adds an explicit member to a private collection. The caller must be able to manage the collection.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The collection ID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Body Parameters
 
-<ApiParam name="member" type="uuid" :required="true">The workspace user's ID.</ApiParam>
-<ApiParam name="access" type="integer" :required="false">`0` (view, default), `1` (comment), or `2` (edit).</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="member" type="uuid" :required="true">
+
+The workspace user's ID.
+
+</ApiParam>
+<ApiParam name="access" type="integer" :required="false">
+
+`0` (view, default), `1` (comment), or `2` (edit).
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Add a collection member" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Add a collection member" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/" \
@@ -35,7 +76,8 @@ curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/collections/co
   -d '{"member":"6f356c85-bb22-47e0-b8b1-cf18aa6adad3","access":0}'
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -44,7 +86,8 @@ response = requests.post(url, headers={"X-API-Key": "your-api-key"}, json={"memb
 print(response.json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/";
@@ -56,7 +99,8 @@ const response = await fetch(url, {
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="201">
 
 ```json
@@ -73,4 +117,8 @@ console.log(await response.json());
 }
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/add-collection-pages.md
+++ b/docs/api-reference/collection/add-collection-pages.md
@@ -6,33 +6,78 @@ keywords: plane, plane api, rest api, collection pages, add pages, page placemen
 
 # Add pages to a collection
 
-<div class="api-endpoint-badge"><span class="method post">POST</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method post">POST</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Adds each selected page and its sub-pages. Adding to a private collection makes the page tree private; adding an owned
 private page to a public collection makes it public. Private collections accept only root pages.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The destination collection ID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The destination collection ID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Body Parameters
 
-<ApiParam name="page_ids" type="uuid[]" :required="true">One or more workspace page IDs.</ApiParam>
-<ApiParam name="sort_orders" type="object" :required="false">Page-ID keys mapped to numeric sort orders. Every key must occur in `page_ids`.</ApiParam>
-<ApiParam name="placement" type="object" :required="false">Placement with `type`: `append`, `before`, or `after`; optional `parent_id`; and required `target_page_id` for `before` or `after`. Before/after accepts exactly one page.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="page_ids" type="uuid[]" :required="true">
+
+One or more workspace page IDs.
+
+</ApiParam>
+<ApiParam name="sort_orders" type="object" :required="false">
+
+Page-ID keys mapped to numeric sort orders. Every key must occur in `page_ids`.
+
+</ApiParam>
+<ApiParam name="placement" type="object" :required="false">
+
+Placement with `type`: `append`, `before`, or `after`; optional `parent_id`; and required `target_page_id` for `before` or `after`. Before/after accepts exactly one page.
+
+</ApiParam>
 
 `placement` takes precedence over `sort_orders`. An `append` placement accepts multiple pages and preserves their order
 from `page_ids`.
 
-### OAuth scope
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Add pages to a collection" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Add pages to a collection" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/" \
@@ -40,7 +85,8 @@ curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/collections/co
   -d '{"page_ids":["ea8ccdab-1cf4-448b-8205-51e4b98d82b8"],"placement":{"type":"append","parent_id":null}}'
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -49,7 +95,8 @@ payload = {"page_ids": ["ea8ccdab-1cf4-448b-8205-51e4b98d82b8"], "placement": {"
 print(requests.post(url, headers={"X-API-Key": "your-api-key"}, json=payload).json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/";
@@ -64,7 +111,8 @@ const response = await fetch(url, {
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="200">
 
 ```json
@@ -83,4 +131,8 @@ console.log(await response.json());
 ]
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/add-collection-pages.md
+++ b/docs/api-reference/collection/add-collection-pages.md
@@ -133,6 +133,9 @@ console.log(await response.json());
 
 </ResponsePanel>
 
+The response `id` is the page placement ID. Use it as `page_collection_id` when moving, reordering, or removing the
+page from a collection.
+
 </div>
 
 </div>

--- a/docs/api-reference/collection/add-collection-pages.md
+++ b/docs/api-reference/collection/add-collection-pages.md
@@ -1,0 +1,86 @@
+---
+title: Add pages to a collection
+description: Add one or more Plane workspace page trees to a collection.
+keywords: plane, plane api, rest api, collection pages, add pages, page placement
+---
+
+# Add pages to a collection
+
+<div class="api-endpoint-badge"><span class="method post">POST</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Adds each selected page and its sub-pages. Adding to a private collection makes the page tree private; adding an owned
+private page to a public collection makes it public. Private collections accept only root pages.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The destination collection ID.</ApiParam>
+
+### Body Parameters
+
+<ApiParam name="page_ids" type="uuid[]" :required="true">One or more workspace page IDs.</ApiParam>
+<ApiParam name="sort_orders" type="object" :required="false">Page-ID keys mapped to numeric sort orders. Every key must occur in `page_ids`.</ApiParam>
+<ApiParam name="placement" type="object" :required="false">Placement with `type`: `append`, `before`, or `after`; optional `parent_id`; and required `target_page_id` for `before` or `after`. Before/after accepts exactly one page.</ApiParam>
+
+`placement` takes precedence over `sort_orders`. An `append` placement accepts multiple pages and preserves their order
+from `page_ids`.
+
+### OAuth scope
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Add pages to a collection" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/" \
+  -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" \
+  -d '{"page_ids":["ea8ccdab-1cf4-448b-8205-51e4b98d82b8"],"placement":{"type":"append","parent_id":null}}'
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/"
+payload = {"page_ids": ["ea8ccdab-1cf4-448b-8205-51e4b98d82b8"], "placement": {"type": "append", "parent_id": None}}
+print(requests.post(url, headers={"X-API-Key": "your-api-key"}, json=payload).json())
+```
+
+</template><template #javascript>
+
+```javascript
+const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/";
+const response = await fetch(url, {
+  method: "POST",
+  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  body: JSON.stringify({
+    page_ids: ["ea8ccdab-1cf4-448b-8205-51e4b98d82b8"],
+    placement: { type: "append", parent_id: null },
+  }),
+});
+console.log(await response.json());
+```
+
+</template></CodePanel>
+<ResponsePanel status="200">
+
+```json
+[
+  {
+    "id": "55ebf2cc-61ba-478a-b88c-88db969e29dc",
+    "collection": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+    "page": "ea8ccdab-1cf4-448b-8205-51e4b98d82b8",
+    "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+    "sort_order": 65535.0,
+    "created_at": "2026-08-18T10:00:00Z",
+    "updated_at": "2026-08-18T10:00:00Z",
+    "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+    "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f"
+  }
+]
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/add-collection-pages.md
+++ b/docs/api-reference/collection/add-collection-pages.md
@@ -99,10 +99,11 @@ print(requests.post(url, headers={"X-API-Key": "your-api-key"}, json=payload).js
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/";
 const response = await fetch(url, {
   method: "POST",
-  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY, "Content-Type": "application/json" },
   body: JSON.stringify({
     page_ids: ["ea8ccdab-1cf4-448b-8205-51e4b98d82b8"],
     placement: { type: "append", parent_id: null },

--- a/docs/api-reference/collection/create-collection.md
+++ b/docs/api-reference/collection/create-collection.md
@@ -1,0 +1,87 @@
+---
+title: Create a collection
+description: Create a public or private collection in a Plane workspace.
+keywords: plane, plane api, rest api, collections, create collection, private collection
+---
+
+# Create a collection
+
+<div class="api-endpoint-badge"><span class="method post">POST</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Creates a collection. Private collections can only be created by workspace admins when the feature is available. The
+creator of a private collection is automatically added as a member with edit access.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+
+### Body Parameters
+
+<ApiParam name="name" type="string" :required="false">The collection name. Defaults to an empty string.</ApiParam>
+<ApiParam name="access" type="integer" :required="false">`0` for public (default) or `1` for private.</ApiParam>
+<ApiParam name="logo_props" type="object" :required="false">Logo or emoji properties. Defaults to an empty object.</ApiParam>
+
+### OAuth scope
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Create a collection" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/collections/" \
+  -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" \
+  -d '{"name":"Product docs","access":0,"logo_props":{"emoji":"📚"}}'
+```
+
+</template><template #python>
+
+```python
+import requests
+
+response = requests.post(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/collections/",
+    headers={"X-API-Key": "your-api-key"},
+    json={"name": "Product docs", "access": 0, "logo_props": {"emoji": "📚"}},
+)
+print(response.json())
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/collections/", {
+  method: "POST",
+  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  body: JSON.stringify({ name: "Product docs", access: 0, logo_props: { emoji: "📚" } }),
+});
+console.log(await response.json());
+```
+
+</template></CodePanel>
+<ResponsePanel status="201">
+
+```json
+{
+  "id": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+  "name": "Product docs",
+  "owned_by_id": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "access": 0,
+  "current_user_access": null,
+  "has_pages": false,
+  "is_default": false,
+  "is_global": true,
+  "logo_props": { "emoji": "📚" },
+  "sort_order": 65535.0,
+  "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+  "created_at": "2026-08-18T10:00:00Z",
+  "updated_at": "2026-08-18T10:00:00Z",
+  "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f"
+}
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/create-collection.md
+++ b/docs/api-reference/collection/create-collection.md
@@ -95,9 +95,10 @@ print(response.json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/collections/", {
   method: "POST",
-  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY, "Content-Type": "application/json" },
   body: JSON.stringify({ name: "Product docs", access: 0, logo_props: { emoji: "📚" } }),
 });
 console.log(await response.json());

--- a/docs/api-reference/collection/create-collection.md
+++ b/docs/api-reference/collection/create-collection.md
@@ -6,28 +6,68 @@ keywords: plane, plane api, rest api, collections, create collection, private co
 
 # Create a collection
 
-<div class="api-endpoint-badge"><span class="method post">POST</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method post">POST</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Creates a collection. Private collections can only be created by workspace admins when the feature is available. The
 creator of a private collection is automatically added as a member with edit access.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Body Parameters
 
-<ApiParam name="name" type="string" :required="false">The collection name. Defaults to an empty string.</ApiParam>
-<ApiParam name="access" type="integer" :required="false">`0` for public (default) or `1` for private.</ApiParam>
-<ApiParam name="logo_props" type="object" :required="false">Logo or emoji properties. Defaults to an empty object.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="name" type="string" :required="false">
+
+The collection name. Defaults to an empty string.
+
+</ApiParam>
+<ApiParam name="access" type="integer" :required="false">
+
+`0` for public (default) or `1` for private.
+
+</ApiParam>
+<ApiParam name="logo_props" type="object" :required="false">
+
+Logo or emoji properties. Defaults to an empty object.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
+</div>
+
+</div>
+
+<div class="api-right">
 <CodePanel title="Create a collection" :languages="['cURL', 'Python', 'JavaScript']">
 <template #curl>
 
@@ -37,7 +77,8 @@ curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/collections/" 
   -d '{"name":"Product docs","access":0,"logo_props":{"emoji":"📚"}}'
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -50,7 +91,8 @@ response = requests.post(
 print(response.json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/collections/", {
@@ -61,7 +103,8 @@ const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspac
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="201">
 
 ```json
@@ -84,4 +127,8 @@ console.log(await response.json());
 }
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/delete-collection.md
+++ b/docs/api-reference/collection/delete-collection.md
@@ -85,9 +85,10 @@ print(response.status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url =
   "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/?archive_pages=false";
-const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": "your-api-key" } });
+const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": process.env.PLANE_API_KEY } });
 console.log(response.status);
 ```
 

--- a/docs/api-reference/collection/delete-collection.md
+++ b/docs/api-reference/collection/delete-collection.md
@@ -6,35 +6,73 @@ keywords: plane, plane api, rest api, collections, delete collection, archive pa
 
 # Delete a collection
 
-<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method delete">DELETE</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Deletes a non-default collection. Pages are archived by default. Set `archive_pages=false` to preserve pages when
 deleting a public collection; pages in a private collection are always archived.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The collection ID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Query Parameters
 
-<ApiParam name="archive_pages" type="boolean" :required="false">Whether to archive contained pages. Defaults to `true`.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="archive_pages" type="boolean" :required="false">
+
+Whether to archive contained pages. Defaults to `true`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Delete a collection" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Delete a collection" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/?archive_pages=false" \
   -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -43,7 +81,8 @@ response = requests.delete(url, headers={"X-API-Key": "your-api-key"}, params={"
 print(response.status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url =
@@ -52,11 +91,16 @@ const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": "y
 console.log(response.status);
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="204">
 
 ```text
 No response body
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/delete-collection.md
+++ b/docs/api-reference/collection/delete-collection.md
@@ -1,0 +1,62 @@
+---
+title: Delete a collection
+description: Delete a non-default Plane collection and optionally preserve its pages.
+keywords: plane, plane api, rest api, collections, delete collection, archive pages
+---
+
+# Delete a collection
+
+<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Deletes a non-default collection. Pages are archived by default. Set `archive_pages=false` to preserve pages when
+deleting a public collection; pages in a private collection are always archived.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+
+### Query Parameters
+
+<ApiParam name="archive_pages" type="boolean" :required="false">Whether to archive contained pages. Defaults to `true`.</ApiParam>
+
+### OAuth scope
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Delete a collection" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/?archive_pages=false" \
+  -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/"
+response = requests.delete(url, headers={"X-API-Key": "your-api-key"}, params={"archive_pages": "false"})
+print(response.status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const url =
+  "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/?archive_pages=false";
+const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": "your-api-key" } });
+console.log(response.status);
+```
+
+</template></CodePanel>
+<ResponsePanel status="204">
+
+```text
+No response body
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/list-collection-members.md
+++ b/docs/api-reference/collection/list-collection-members.md
@@ -67,8 +67,9 @@ print(requests.get(url, headers={"X-API-Key": "your-api-key"}).json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/";
-const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
+const response = await fetch(url, { headers: { "X-API-Key": process.env.PLANE_API_KEY } });
 console.log(await response.json());
 ```
 

--- a/docs/api-reference/collection/list-collection-members.md
+++ b/docs/api-reference/collection/list-collection-members.md
@@ -6,29 +6,56 @@ keywords: plane, plane api, rest api, collection members, list members
 
 # List collection members
 
-<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Returns explicit collection memberships.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The collection ID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `read` or `wiki.pages:read`
 
-</div><div class="api-right">
-<CodePanel title="List collection members" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="List collection members" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -36,7 +63,8 @@ url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collectio
 print(requests.get(url, headers={"X-API-Key": "your-api-key"}).json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/";
@@ -44,7 +72,8 @@ const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="200">
 
 ```json
@@ -63,4 +92,8 @@ console.log(await response.json());
 ]
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/list-collection-members.md
+++ b/docs/api-reference/collection/list-collection-members.md
@@ -1,0 +1,66 @@
+---
+title: List collection members
+description: List users who have explicit access to a Plane collection.
+keywords: plane, plane api, rest api, collection members, list members
+---
+
+# List collection members
+
+<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Returns explicit collection memberships.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+
+### OAuth scope
+
+`read` or `wiki.pages:read`
+
+</div><div class="api-right">
+<CodePanel title="List collection members" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/"
+print(requests.get(url, headers={"X-API-Key": "your-api-key"}).json())
+```
+
+</template><template #javascript>
+
+```javascript
+const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/";
+const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
+console.log(await response.json());
+```
+
+</template></CodePanel>
+<ResponsePanel status="200">
+
+```json
+[
+  {
+    "id": "4edec253-26f4-4667-8f52-9488dca1c620",
+    "collection": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+    "member": "6f356c85-bb22-47e0-b8b1-cf18aa6adad3",
+    "access": 0,
+    "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+    "created_at": "2026-08-18T10:00:00Z",
+    "updated_at": "2026-08-18T10:00:00Z",
+    "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+    "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f"
+  }
+]
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/list-collection-pages.md
+++ b/docs/api-reference/collection/list-collection-pages.md
@@ -140,9 +140,10 @@ print(response.json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url =
   "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/?search=API&per_page=50";
-const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
+const response = await fetch(url, { headers: { "X-API-Key": process.env.PLANE_API_KEY } });
 console.log(await response.json());
 ```
 

--- a/docs/api-reference/collection/list-collection-pages.md
+++ b/docs/api-reference/collection/list-collection-pages.md
@@ -6,46 +6,128 @@ keywords: plane, plane api, rest api, collection pages, list pages, page filters
 
 # List collection pages
 
-<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Returns a paginated branch of visible pages. By default, it returns the collection's root pages.
 Pass `next_cursor` back as `cursor` to continue until `next_page_results` is `false`.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The collection ID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Query Parameters
 
-<ApiParam name="parent_id" type="uuid" :required="false">Return direct children of this page.</ApiParam>
-<ApiParam name="search" type="string" :required="false">Case-insensitive page-name search.</ApiParam>
-<ApiParam name="created_by" type="string" :required="false">Comma-separated creator IDs.</ApiParam>
-<ApiParam name="favorites" type="boolean" :required="false">Filter by the current user's favorite status.</ApiParam>
-<ApiParam name="labels" type="string" :required="false">Comma-separated label IDs.</ApiParam>
-<ApiParam name="created_at__gte" type="date" :required="false">Created on or after this date.</ApiParam>
-<ApiParam name="created_at__lte" type="date" :required="false">Created on or before this date.</ApiParam>
-<ApiParam name="owned_by_id" type="uuid" :required="false">Filter by owner.</ApiParam>
-<ApiParam name="owned_by_id__in" type="string" :required="false">Comma-separated owner IDs.</ApiParam>
-<ApiParam name="parent_id__in" type="string" :required="false">Comma-separated parent IDs.</ApiParam>
-<ApiParam name="per_page" type="integer" :required="false">Results per page. Defaults to 50; maximum 100.</ApiParam>
-<ApiParam name="cursor" type="string" :required="false">Cursor returned by a previous page.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="parent_id" type="uuid" :required="false">
+
+Return direct children of this page.
+
+</ApiParam>
+<ApiParam name="search" type="string" :required="false">
+
+Case-insensitive page-name search.
+
+</ApiParam>
+<ApiParam name="created_by" type="string" :required="false">
+
+Comma-separated creator IDs.
+
+</ApiParam>
+<ApiParam name="favorites" type="boolean" :required="false">
+
+Filter by the current user's favorite status.
+
+</ApiParam>
+<ApiParam name="labels" type="string" :required="false">
+
+Comma-separated label IDs.
+
+</ApiParam>
+<ApiParam name="created_at__gte" type="date" :required="false">
+
+Created on or after this date.
+
+</ApiParam>
+<ApiParam name="created_at__lte" type="date" :required="false">
+
+Created on or before this date.
+
+</ApiParam>
+<ApiParam name="owned_by_id" type="uuid" :required="false">
+
+Filter by owner.
+
+</ApiParam>
+<ApiParam name="owned_by_id__in" type="string" :required="false">
+
+Comma-separated owner IDs.
+
+</ApiParam>
+<ApiParam name="parent_id__in" type="string" :required="false">
+
+Comma-separated parent IDs.
+
+</ApiParam>
+<ApiParam name="per_page" type="integer" :required="false">
+
+Results per page. Defaults to 50; maximum 100.
+
+</ApiParam>
+<ApiParam name="cursor" type="string" :required="false">
+
+Cursor returned by a previous page.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `read` or `wiki.pages:read`
 
-</div><div class="api-right">
-<CodePanel title="List collection pages" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="List collection pages" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/?search=API&per_page=50" \
   -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -54,7 +136,8 @@ response = requests.get(url, headers={"X-API-Key": "your-api-key"}, params={"sea
 print(response.json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url =
@@ -63,7 +146,8 @@ const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="200">
 
 ```json
@@ -105,4 +189,8 @@ console.log(await response.json());
 }
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/list-collection-pages.md
+++ b/docs/api-reference/collection/list-collection-pages.md
@@ -1,0 +1,108 @@
+---
+title: List collection pages
+description: List and filter a branch of pages in a Plane collection.
+keywords: plane, plane api, rest api, collection pages, list pages, page filters
+---
+
+# List collection pages
+
+<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Returns a paginated branch of visible pages. By default, it returns the collection's root pages.
+Pass `next_cursor` back as `cursor` to continue until `next_page_results` is `false`.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+
+### Query Parameters
+
+<ApiParam name="parent_id" type="uuid" :required="false">Return direct children of this page.</ApiParam>
+<ApiParam name="search" type="string" :required="false">Case-insensitive page-name search.</ApiParam>
+<ApiParam name="created_by" type="string" :required="false">Comma-separated creator IDs.</ApiParam>
+<ApiParam name="favorites" type="boolean" :required="false">Filter by the current user's favorite status.</ApiParam>
+<ApiParam name="labels" type="string" :required="false">Comma-separated label IDs.</ApiParam>
+<ApiParam name="created_at__gte" type="date" :required="false">Created on or after this date.</ApiParam>
+<ApiParam name="created_at__lte" type="date" :required="false">Created on or before this date.</ApiParam>
+<ApiParam name="owned_by_id" type="uuid" :required="false">Filter by owner.</ApiParam>
+<ApiParam name="owned_by_id__in" type="string" :required="false">Comma-separated owner IDs.</ApiParam>
+<ApiParam name="parent_id__in" type="string" :required="false">Comma-separated parent IDs.</ApiParam>
+<ApiParam name="per_page" type="integer" :required="false">Results per page. Defaults to 50; maximum 100.</ApiParam>
+<ApiParam name="cursor" type="string" :required="false">Cursor returned by a previous page.</ApiParam>
+
+### OAuth scope
+
+`read` or `wiki.pages:read`
+
+</div><div class="api-right">
+<CodePanel title="List collection pages" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/?search=API&per_page=50" \
+  -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/"
+response = requests.get(url, headers={"X-API-Key": "your-api-key"}, params={"search": "API", "per_page": 50})
+print(response.json())
+```
+
+</template><template #javascript>
+
+```javascript
+const url =
+  "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/?search=API&per_page=50";
+const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
+console.log(await response.json());
+```
+
+</template></CodePanel>
+<ResponsePanel status="200">
+
+```json
+{
+  "next_cursor": "50:50:0",
+  "prev_cursor": "50:0:0",
+  "next_page_results": false,
+  "prev_page_results": false,
+  "count": 1,
+  "total_pages": 1,
+  "total_results": 1,
+  "extra_stats": null,
+  "results": [
+    {
+      "page_collection_id": "55ebf2cc-61ba-478a-b88c-88db969e29dc",
+      "collection_id": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+      "parent_id": null,
+      "sort_order": 65535.0,
+      "page": {
+        "id": "ea8ccdab-1cf4-448b-8205-51e4b98d82b8",
+        "name": "API guide",
+        "access": 0,
+        "logo_props": {},
+        "parent_id": null,
+        "collection_id": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+        "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+        "sub_pages_count": 2,
+        "is_shared": false,
+        "owned_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+        "updated_at": "2026-08-18T10:00:00Z",
+        "created_at": "2026-08-18T10:00:00Z",
+        "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+        "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+        "is_favorite": false,
+        "label_ids": []
+      }
+    }
+  ]
+}
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/list-collections.md
+++ b/docs/api-reference/collection/list-collections.md
@@ -1,0 +1,81 @@
+---
+title: List collections
+description: List the collections visible to the authenticated user in a Plane workspace.
+keywords: plane, plane api, rest api, collections, list collections, wiki
+---
+
+# List collections
+
+<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Returns all public and permitted private collections in sort order. A private collection is included when the caller
+owns it, is a workspace admin, or is an explicit collection member.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+
+### OAuth scope
+
+`read` or `wiki.pages:read`
+
+</div><div class="api-right">
+
+<CodePanel title="List collections" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl "https://api.plane.so/api/v1/workspaces/my-workspace/collections/" \
+  -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+
+response = requests.get(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/collections/",
+    headers={"X-API-Key": "your-api-key"},
+)
+print(response.json())
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/collections/", {
+  headers: { "X-API-Key": "your-api-key" },
+});
+console.log(await response.json());
+```
+
+</template></CodePanel>
+
+<ResponsePanel status="200">
+
+```json
+[
+  {
+    "id": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+    "name": "Product docs",
+    "owned_by_id": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+    "access": 0,
+    "current_user_access": null,
+    "has_pages": true,
+    "is_default": false,
+    "is_global": true,
+    "logo_props": {},
+    "sort_order": 65535.0,
+    "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+    "created_at": "2026-08-18T10:00:00Z",
+    "updated_at": "2026-08-18T10:00:00Z",
+    "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+    "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f"
+  }
+]
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/list-collections.md
+++ b/docs/api-reference/collection/list-collections.md
@@ -69,8 +69,9 @@ print(response.json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/collections/", {
-  headers: { "X-API-Key": "your-api-key" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY },
 });
 console.log(await response.json());
 ```

--- a/docs/api-reference/collection/list-collections.md
+++ b/docs/api-reference/collection/list-collections.md
@@ -6,22 +6,43 @@ keywords: plane, plane api, rest api, collections, list collections, wiki
 
 # List collections
 
-<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Returns all public and permitted private collections in sort order. A private collection is included when the caller
 owns it, is a workspace admin, or is an explicit collection member.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `read` or `wiki.pages:read`
 
-</div><div class="api-right">
+</div>
+
+</div>
+
+<div class="api-right">
 
 <CodePanel title="List collections" :languages="['cURL', 'Python', 'JavaScript']">
 <template #curl>
@@ -31,7 +52,8 @@ curl "https://api.plane.so/api/v1/workspaces/my-workspace/collections/" \
   -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -43,7 +65,8 @@ response = requests.get(
 print(response.json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/collections/", {
@@ -52,7 +75,8 @@ const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspac
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 
 <ResponsePanel status="200">
 
@@ -78,4 +102,8 @@ console.log(await response.json());
 ]
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/move-or-reorder-collection-page.md
+++ b/docs/api-reference/collection/move-or-reorder-collection-page.md
@@ -1,0 +1,81 @@
+---
+title: Move or reorder a collection page
+description: Move a Plane page tree to another collection or change its collection order.
+keywords: plane, plane api, rest api, collection pages, move page, reorder page
+---
+
+# Move or reorder a collection page
+
+<div class="api-endpoint-badge"><span class="method patch">PATCH</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/{page_collection_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Reorders a page or moves its page tree to another visible collection. A private collection's sub-page cannot be moved
+independently. Moving a private page to a public collection makes its tree public when permitted. Moving a root page
+out of a private collection requires workspace admin access, or ownership of the page tree together with edit access
+to the source collection. Moving into a private collection also requires access to the destination collection.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The source collection ID.</ApiParam>
+<ApiParam name="page_collection_id" type="uuid" :required="true">The page membership ID returned as `page_collection_id` by the list endpoint.</ApiParam>
+
+### Body Parameters
+
+<ApiParam name="collection" type="uuid" :required="false">A destination collection ID. Omit or use the source ID to reorder in place.</ApiParam>
+<ApiParam name="sort_order" type="number" :required="false">An explicit ordering value.</ApiParam>
+<ApiParam name="placement" type="object" :required="false">Placement with `type`: `append`, `before`, or `after`; optional `parent_id`; and required `target_page_id` for before/after. Overrides `sort_order`.</ApiParam>
+
+### OAuth scope
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Move or reorder a collection page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X PATCH "https://api.plane.so/api/v1/workspaces/my-workspace/collections/source-uuid/pages/membership-uuid/" \
+  -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" \
+  -d '{"collection":"target-collection-uuid","placement":{"type":"append"}}'
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/source-uuid/pages/membership-uuid/"
+payload = {"collection": "target-collection-uuid", "placement": {"type": "append"}}
+print(requests.patch(url, headers={"X-API-Key": "your-api-key"}, json=payload).json())
+```
+
+</template><template #javascript>
+
+```javascript
+const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/source-uuid/pages/membership-uuid/";
+const response = await fetch(url, {
+  method: "PATCH",
+  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  body: JSON.stringify({ collection: "target-collection-uuid", placement: { type: "append" } }),
+});
+console.log(await response.json());
+```
+
+</template></CodePanel>
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "55ebf2cc-61ba-478a-b88c-88db969e29dc",
+  "collection": "82c72604-2019-43b7-930f-692af61f3ea7",
+  "page": "ea8ccdab-1cf4-448b-8205-51e4b98d82b8",
+  "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+  "sort_order": 65535.0,
+  "created_at": "2026-08-18T10:00:00Z",
+  "updated_at": "2026-08-18T10:05:00Z",
+  "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f"
+}
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/move-or-reorder-collection-page.md
+++ b/docs/api-reference/collection/move-or-reorder-collection-page.md
@@ -6,33 +6,82 @@ keywords: plane, plane api, rest api, collection pages, move page, reorder page
 
 # Move or reorder a collection page
 
-<div class="api-endpoint-badge"><span class="method patch">PATCH</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/{page_collection_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method patch">PATCH</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/{page_collection_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Reorders a page or moves its page tree to another visible collection. A private collection's sub-page cannot be moved
 independently. Moving a private page to a public collection makes its tree public when permitted. Moving a root page
 out of a private collection requires workspace admin access, or ownership of the page tree together with edit access
 to the source collection. Moving into a private collection also requires access to the destination collection.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The source collection ID.</ApiParam>
-<ApiParam name="page_collection_id" type="uuid" :required="true">The page membership ID returned as `page_collection_id` by the list endpoint.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The source collection ID.
+
+</ApiParam>
+<ApiParam name="page_collection_id" type="uuid" :required="true">
+
+The page membership ID returned as `page_collection_id` by the list endpoint.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Body Parameters
 
-<ApiParam name="collection" type="uuid" :required="false">A destination collection ID. Omit or use the source ID to reorder in place.</ApiParam>
-<ApiParam name="sort_order" type="number" :required="false">An explicit ordering value.</ApiParam>
-<ApiParam name="placement" type="object" :required="false">Placement with `type`: `append`, `before`, or `after`; optional `parent_id`; and required `target_page_id` for before/after. Overrides `sort_order`.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="collection" type="uuid" :required="false">
+
+A destination collection ID. Omit or use the source ID to reorder in place.
+
+</ApiParam>
+<ApiParam name="sort_order" type="number" :required="false">
+
+An explicit ordering value.
+
+</ApiParam>
+<ApiParam name="placement" type="object" :required="false">
+
+Placement with `type`: `append`, `before`, or `after`; optional `parent_id`; and required `target_page_id` for before/after. Overrides `sort_order`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Move or reorder a collection page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Move or reorder a collection page" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X PATCH "https://api.plane.so/api/v1/workspaces/my-workspace/collections/source-uuid/pages/membership-uuid/" \
@@ -40,7 +89,8 @@ curl -X PATCH "https://api.plane.so/api/v1/workspaces/my-workspace/collections/s
   -d '{"collection":"target-collection-uuid","placement":{"type":"append"}}'
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -49,7 +99,8 @@ payload = {"collection": "target-collection-uuid", "placement": {"type": "append
 print(requests.patch(url, headers={"X-API-Key": "your-api-key"}, json=payload).json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/source-uuid/pages/membership-uuid/";
@@ -61,7 +112,8 @@ const response = await fetch(url, {
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="200">
 
 ```json
@@ -78,4 +130,8 @@ console.log(await response.json());
 }
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/move-or-reorder-collection-page.md
+++ b/docs/api-reference/collection/move-or-reorder-collection-page.md
@@ -103,10 +103,11 @@ print(requests.patch(url, headers={"X-API-Key": "your-api-key"}, json=payload).j
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/source-uuid/pages/membership-uuid/";
 const response = await fetch(url, {
   method: "PATCH",
-  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY, "Content-Type": "application/json" },
   body: JSON.stringify({ collection: "target-collection-uuid", placement: { type: "append" } }),
 });
 console.log(await response.json());

--- a/docs/api-reference/collection/overview.md
+++ b/docs/api-reference/collection/overview.md
@@ -43,3 +43,11 @@ creator of a private collection is automatically added with edit access.
 
 Collection edit access allows a member to edit content and arrange pages, but it does not grant collection ownership.
 Only the collection owner or a workspace admin can add, update, or remove collection members.
+
+## Common errors
+
+| Status | Cause                                                                                                          |
+| ------ | -------------------------------------------------------------------------------------------------------------- |
+| `400`  | Invalid request payload or page placement, or an attempt to modify or delete the protected default collection. |
+| `403`  | Insufficient collection or workspace permissions, or unavailable private-collection feature access.            |
+| `404`  | The collection, page, membership, or other requested resource is unavailable or inaccessible to the caller.    |

--- a/docs/api-reference/collection/overview.md
+++ b/docs/api-reference/collection/overview.md
@@ -1,0 +1,45 @@
+---
+title: Collection API overview
+description: Organize Plane workspace pages into public or private collections and manage collection membership.
+keywords: plane, plane api, rest api, collections, wiki pages, collection members
+---
+
+# Collection API overview
+
+Collections organize workspace wiki pages. Public collections are visible according to workspace permissions; private
+collections are visible only to permitted users. A page and its sub-pages move together when the page is added, moved,
+or removed.
+
+## Collection object
+
+<ResponsePanel status="200" title="COLLECTION OBJECT">
+
+```json
+{
+  "id": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+  "name": "Product docs",
+  "owned_by_id": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "access": 0,
+  "current_user_access": null,
+  "has_pages": true,
+  "is_default": false,
+  "is_global": true,
+  "logo_props": { "emoji": "📚" },
+  "sort_order": 65535.0,
+  "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+  "created_at": "2026-08-18T10:00:00Z",
+  "updated_at": "2026-08-18T10:00:00Z",
+  "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f"
+}
+```
+
+</ResponsePanel>
+
+`access` is `0` for public or `1` for private. `current_user_access` is `null` for a public collection. For a private
+collection, member access is `0` (view), `1` (comment), or `2` (edit). Collection access cannot be changed after
+creation. Private collections require the private collections feature, and only workspace admins can create them. The
+creator of a private collection is automatically added with edit access.
+
+Collection edit access allows a member to edit content and arrange pages, but it does not grant collection ownership.
+Only the collection owner or a workspace admin can add, update, or remove collection members.

--- a/docs/api-reference/collection/remove-collection-member.md
+++ b/docs/api-reference/collection/remove-collection-member.md
@@ -1,0 +1,55 @@
+---
+title: Remove a collection member
+description: Revoke a user's explicit access to a private Plane collection.
+keywords: plane, plane api, rest api, collection members, remove member
+---
+
+# Remove a collection member
+
+<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/{member_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Removes an explicit collection membership. `member_id` identifies the membership record, not the user.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+<ApiParam name="member_id" type="uuid" :required="true">The collection membership ID.</ApiParam>
+
+### OAuth scope
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Remove a collection member" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/"
+print(requests.delete(url, headers={"X-API-Key": "your-api-key"}).status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/";
+const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": "your-api-key" } });
+console.log(response.status);
+```
+
+</template></CodePanel>
+<ResponsePanel status="204">
+
+```text
+No response body
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/remove-collection-member.md
+++ b/docs/api-reference/collection/remove-collection-member.md
@@ -6,30 +6,61 @@ keywords: plane, plane api, rest api, collection members, remove member
 
 # Remove a collection member
 
-<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/{member_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method delete">DELETE</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/{member_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Removes an explicit collection membership. `member_id` identifies the membership record, not the user.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
-<ApiParam name="member_id" type="uuid" :required="true">The collection membership ID.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The collection ID.
+
+</ApiParam>
+<ApiParam name="member_id" type="uuid" :required="true">
+
+The collection membership ID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Remove a collection member" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Remove a collection member" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -37,7 +68,8 @@ url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collectio
 print(requests.delete(url, headers={"X-API-Key": "your-api-key"}).status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/";
@@ -45,11 +77,16 @@ const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": "y
 console.log(response.status);
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="204">
 
 ```text
 No response body
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/remove-collection-member.md
+++ b/docs/api-reference/collection/remove-collection-member.md
@@ -72,8 +72,9 @@ print(requests.delete(url, headers={"X-API-Key": "your-api-key"}).status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/";
-const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": "your-api-key" } });
+const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": process.env.PLANE_API_KEY } });
 console.log(response.status);
 ```
 

--- a/docs/api-reference/collection/remove-collection-page.md
+++ b/docs/api-reference/collection/remove-collection-page.md
@@ -6,31 +6,62 @@ keywords: plane, plane api, rest api, collection pages, remove page
 
 # Remove a page from a collection
 
-<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/{page_collection_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method delete">DELETE</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/{page_collection_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Removes the page and its descendants from the collection. A sub-page cannot be removed independently from a private
 collection. Removing a private collection root requires permission to move that page tree out of the collection.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
-<ApiParam name="page_collection_id" type="uuid" :required="true">The page membership ID returned as `page_collection_id` by the list endpoint.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The collection ID.
+
+</ApiParam>
+<ApiParam name="page_collection_id" type="uuid" :required="true">
+
+The page membership ID returned as `page_collection_id` by the list endpoint.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Remove a page from a collection" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Remove a page from a collection" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/membership-uuid/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -38,7 +69,8 @@ url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collectio
 print(requests.delete(url, headers={"X-API-Key": "your-api-key"}).status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/membership-uuid/";
@@ -46,11 +78,16 @@ const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": "y
 console.log(response.status);
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="204">
 
 ```text
 No response body
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/remove-collection-page.md
+++ b/docs/api-reference/collection/remove-collection-page.md
@@ -1,0 +1,56 @@
+---
+title: Remove a page from a collection
+description: Remove a Plane page tree from its collection.
+keywords: plane, plane api, rest api, collection pages, remove page
+---
+
+# Remove a page from a collection
+
+<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages/{page_collection_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Removes the page and its descendants from the collection. A sub-page cannot be removed independently from a private
+collection. Removing a private collection root requires permission to move that page tree out of the collection.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+<ApiParam name="page_collection_id" type="uuid" :required="true">The page membership ID returned as `page_collection_id` by the list endpoint.</ApiParam>
+
+### OAuth scope
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Remove a page from a collection" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/membership-uuid/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/membership-uuid/"
+print(requests.delete(url, headers={"X-API-Key": "your-api-key"}).status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/membership-uuid/";
+const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": "your-api-key" } });
+console.log(response.status);
+```
+
+</template></CodePanel>
+<ResponsePanel status="204">
+
+```text
+No response body
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/remove-collection-page.md
+++ b/docs/api-reference/collection/remove-collection-page.md
@@ -73,8 +73,9 @@ print(requests.delete(url, headers={"X-API-Key": "your-api-key"}).status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages/membership-uuid/";
-const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": "your-api-key" } });
+const response = await fetch(url, { method: "DELETE", headers: { "X-API-Key": process.env.PLANE_API_KEY } });
 console.log(response.status);
 ```
 

--- a/docs/api-reference/collection/retrieve-collection.md
+++ b/docs/api-reference/collection/retrieve-collection.md
@@ -68,8 +68,9 @@ print(requests.get(url, headers={"X-API-Key": "your-api-key"}).json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/";
-const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
+const response = await fetch(url, { headers: { "X-API-Key": process.env.PLANE_API_KEY } });
 console.log(await response.json());
 ```
 

--- a/docs/api-reference/collection/retrieve-collection.md
+++ b/docs/api-reference/collection/retrieve-collection.md
@@ -1,0 +1,71 @@
+---
+title: Retrieve a collection
+description: Retrieve a visible Plane workspace collection by ID.
+keywords: plane, plane api, rest api, collections, retrieve collection
+---
+
+# Retrieve a collection
+
+<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Returns a collection if the authenticated user can view it. An inaccessible private collection returns `404 Not Found`.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+
+### OAuth scope
+
+`read` or `wiki.pages:read`
+
+</div><div class="api-right">
+<CodePanel title="Retrieve a collection" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/" \
+  -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/"
+print(requests.get(url, headers={"X-API-Key": "your-api-key"}).json())
+```
+
+</template><template #javascript>
+
+```javascript
+const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/";
+const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
+console.log(await response.json());
+```
+
+</template></CodePanel>
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+  "name": "Product docs",
+  "owned_by_id": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "access": 0,
+  "current_user_access": null,
+  "has_pages": true,
+  "is_default": false,
+  "is_global": true,
+  "logo_props": {},
+  "sort_order": 65535.0,
+  "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+  "created_at": "2026-08-18T10:00:00Z",
+  "updated_at": "2026-08-18T10:00:00Z",
+  "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f"
+}
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/retrieve-collection.md
+++ b/docs/api-reference/collection/retrieve-collection.md
@@ -6,30 +6,57 @@ keywords: plane, plane api, rest api, collections, retrieve collection
 
 # Retrieve a collection
 
-<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Returns a collection if the authenticated user can view it. An inaccessible private collection returns `404 Not Found`.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The collection ID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `read` or `wiki.pages:read`
 
-</div><div class="api-right">
-<CodePanel title="Retrieve a collection" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Retrieve a collection" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/" \
   -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -37,7 +64,8 @@ url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-
 print(requests.get(url, headers={"X-API-Key": "your-api-key"}).json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/";
@@ -45,7 +73,8 @@ const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="200">
 
 ```json
@@ -68,4 +97,8 @@ console.log(await response.json());
 }
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/search-collection-pages.md
+++ b/docs/api-reference/collection/search-collection-pages.md
@@ -1,0 +1,66 @@
+---
+title: Search addable collection pages
+description: Search for workspace pages that can be added to a Plane collection.
+keywords: plane, plane api, rest api, collection pages, search pages, addable pages
+---
+
+# Search addable collection pages
+
+<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages-search/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Returns eligible root pages that are not already assigned to the collection. Results respect page and private
+collection permissions. Without `search`, the endpoint returns at most 10 results. With `search`, it performs a
+case-insensitive page-name search without that limit.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The destination collection ID.</ApiParam>
+
+### Query Parameters
+
+<ApiParam name="search" type="string" :required="false">A page-name search string.</ApiParam>
+
+### OAuth scope
+
+`read` or `wiki.pages:read`
+
+</div><div class="api-right">
+<CodePanel title="Search addable collection pages" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages-search/?search=API" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages-search/"
+print(requests.get(url, headers={"X-API-Key": "your-api-key"}, params={"search": "API"}).json())
+```
+
+</template><template #javascript>
+
+```javascript
+const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages-search/?search=API";
+const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
+console.log(await response.json());
+```
+
+</template></CodePanel>
+<ResponsePanel status="200">
+
+```json
+[
+  {
+    "id": "ea8ccdab-1cf4-448b-8205-51e4b98d82b8",
+    "name": "API guide",
+    "logo_props": { "emoji": "📘" }
+  }
+]
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/search-collection-pages.md
+++ b/docs/api-reference/collection/search-collection-pages.md
@@ -84,8 +84,9 @@ print(requests.get(url, headers={"X-API-Key": "your-api-key"}, params={"search":
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages-search/?search=API";
-const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
+const response = await fetch(url, { headers: { "X-API-Key": process.env.PLANE_API_KEY } });
 console.log(await response.json());
 ```
 

--- a/docs/api-reference/collection/search-collection-pages.md
+++ b/docs/api-reference/collection/search-collection-pages.md
@@ -6,35 +6,73 @@ keywords: plane, plane api, rest api, collection pages, search pages, addable pa
 
 # Search addable collection pages
 
-<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages-search/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/pages-search/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Returns eligible root pages that are not already assigned to the collection. Results respect page and private
 collection permissions. Without `search`, the endpoint returns at most 10 results. With `search`, it performs a
 case-insensitive page-name search without that limit.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The destination collection ID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The destination collection ID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Query Parameters
 
-<ApiParam name="search" type="string" :required="false">A page-name search string.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="search" type="string" :required="false">
+
+A page-name search string.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `read` or `wiki.pages:read`
 
-</div><div class="api-right">
-<CodePanel title="Search addable collection pages" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Search addable collection pages" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages-search/?search=API" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -42,7 +80,8 @@ url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collectio
 print(requests.get(url, headers={"X-API-Key": "your-api-key"}, params={"search": "API"}).json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/pages-search/?search=API";
@@ -50,7 +89,8 @@ const response = await fetch(url, { headers: { "X-API-Key": "your-api-key" } });
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="200">
 
 ```json
@@ -63,4 +103,8 @@ console.log(await response.json());
 ]
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/update-collection-member.md
+++ b/docs/api-reference/collection/update-collection-member.md
@@ -6,35 +6,77 @@ keywords: plane, plane api, rest api, collection members, update member access
 
 # Update a collection member
 
-<div class="api-endpoint-badge"><span class="method patch">PATCH</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/{member_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method patch">PATCH</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/{member_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Changes an explicit collection membership's access level. `member_id` identifies the membership record, not the user.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
-<ApiParam name="member_id" type="uuid" :required="true">The collection membership ID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The collection ID.
+
+</ApiParam>
+<ApiParam name="member_id" type="uuid" :required="true">
+
+The collection membership ID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Body Parameters
 
-<ApiParam name="access" type="integer" :required="false">`0` (view), `1` (comment), or `2` (edit).</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="access" type="integer" :required="false">
+
+`0` (view), `1` (comment), or `2` (edit).
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Update a collection member" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Update a collection member" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X PATCH "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/" \
   -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" -d '{"access":2}'
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -42,7 +84,8 @@ url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collectio
 print(requests.patch(url, headers={"X-API-Key": "your-api-key"}, json={"access": 2}).json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/";
@@ -54,7 +97,8 @@ const response = await fetch(url, {
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="200">
 
 ```json
@@ -71,4 +115,8 @@ console.log(await response.json());
 }
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/update-collection-member.md
+++ b/docs/api-reference/collection/update-collection-member.md
@@ -88,10 +88,11 @@ print(requests.patch(url, headers={"X-API-Key": "your-api-key"}, json={"access":
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/";
 const response = await fetch(url, {
   method: "PATCH",
-  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY, "Content-Type": "application/json" },
   body: JSON.stringify({ access: 2 }),
 });
 console.log(await response.json());

--- a/docs/api-reference/collection/update-collection-member.md
+++ b/docs/api-reference/collection/update-collection-member.md
@@ -1,0 +1,74 @@
+---
+title: Update a collection member
+description: Change a Plane collection member's access level.
+keywords: plane, plane api, rest api, collection members, update member access
+---
+
+# Update a collection member
+
+<div class="api-endpoint-badge"><span class="method patch">PATCH</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/members/{member_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Changes an explicit collection membership's access level. `member_id` identifies the membership record, not the user.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+<ApiParam name="member_id" type="uuid" :required="true">The collection membership ID.</ApiParam>
+
+### Body Parameters
+
+<ApiParam name="access" type="integer" :required="false">`0` (view), `1` (comment), or `2` (edit).</ApiParam>
+
+### OAuth scope
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Update a collection member" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X PATCH "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/" \
+  -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" -d '{"access":2}'
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/"
+print(requests.patch(url, headers={"X-API-Key": "your-api-key"}, json={"access": 2}).json())
+```
+
+</template><template #javascript>
+
+```javascript
+const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/collection-uuid/members/membership-uuid/";
+const response = await fetch(url, {
+  method: "PATCH",
+  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  body: JSON.stringify({ access: 2 }),
+});
+console.log(await response.json());
+```
+
+</template></CodePanel>
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "4edec253-26f4-4667-8f52-9488dca1c620",
+  "collection": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+  "member": "6f356c85-bb22-47e0-b8b1-cf18aa6adad3",
+  "access": 2,
+  "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+  "created_at": "2026-08-18T10:00:00Z",
+  "updated_at": "2026-08-18T10:05:00Z",
+  "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f"
+}
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/collection/update-collection.md
+++ b/docs/api-reference/collection/update-collection.md
@@ -6,29 +6,74 @@ keywords: plane, plane api, rest api, collections, update collection
 
 # Update a collection
 
-<div class="api-endpoint-badge"><span class="method patch">PATCH</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method patch">PATCH</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Partially updates a collection. Its public or private access cannot be changed after creation.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
-<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace slug.
+
+</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">
+
+The collection ID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Body Parameters
 
-<ApiParam name="name" type="string" :required="false">A new collection name.</ApiParam>
-<ApiParam name="logo_props" type="object" :required="false">New logo or emoji properties.</ApiParam>
-<ApiParam name="sort_order" type="number" :required="false">The collection's ordering value.</ApiParam>
+<div class="params-list">
 
-### OAuth scope
+<ApiParam name="name" type="string" :required="false">
+
+A new collection name.
+
+</ApiParam>
+<ApiParam name="logo_props" type="object" :required="false">
+
+New logo or emoji properties.
+
+</ApiParam>
+<ApiParam name="sort_order" type="number" :required="false">
+
+The collection's ordering value.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
+
+### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Update a collection" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Update a collection" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X PATCH "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/" \
@@ -36,7 +81,8 @@ curl -X PATCH "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0
   -d '{"name":"API docs","sort_order":25000}'
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -45,7 +91,8 @@ response = requests.patch(url, headers={"X-API-Key": "your-api-key"}, json={"nam
 print(response.json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/";
@@ -57,7 +104,8 @@ const response = await fetch(url, {
 console.log(await response.json());
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="200">
 
 ```json
@@ -80,4 +128,8 @@ console.log(await response.json());
 }
 ```
 
-</ResponsePanel></div></div>
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/collection/update-collection.md
+++ b/docs/api-reference/collection/update-collection.md
@@ -95,10 +95,11 @@ print(response.json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/";
 const response = await fetch(url, {
   method: "PATCH",
-  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY, "Content-Type": "application/json" },
   body: JSON.stringify({ name: "API docs", sort_order: 25000 }),
 });
 console.log(await response.json());

--- a/docs/api-reference/collection/update-collection.md
+++ b/docs/api-reference/collection/update-collection.md
@@ -1,0 +1,83 @@
+---
+title: Update a collection
+description: Update a Plane collection's name, logo, or sort order.
+keywords: plane, plane api, rest api, collections, update collection
+---
+
+# Update a collection
+
+<div class="api-endpoint-badge"><span class="method patch">PATCH</span><span class="path">/api/v1/workspaces/{workspace_slug}/collections/{collection_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Partially updates a collection. Its public or private access cannot be changed after creation.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace slug.</ApiParam>
+<ApiParam name="collection_id" type="uuid" :required="true">The collection ID.</ApiParam>
+
+### Body Parameters
+
+<ApiParam name="name" type="string" :required="false">A new collection name.</ApiParam>
+<ApiParam name="logo_props" type="object" :required="false">New logo or emoji properties.</ApiParam>
+<ApiParam name="sort_order" type="number" :required="false">The collection's ordering value.</ApiParam>
+
+### OAuth scope
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Update a collection" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X PATCH "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/" \
+  -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" \
+  -d '{"name":"API docs","sort_order":25000}'
+```
+
+</template><template #python>
+
+```python
+import requests
+url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/"
+response = requests.patch(url, headers={"X-API-Key": "your-api-key"}, json={"name": "API docs", "sort_order": 25000})
+print(response.json())
+```
+
+</template><template #javascript>
+
+```javascript
+const url = "https://api.plane.so/api/v1/workspaces/my-workspace/collections/0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10/";
+const response = await fetch(url, {
+  method: "PATCH",
+  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  body: JSON.stringify({ name: "API docs", sort_order: 25000 }),
+});
+console.log(await response.json());
+```
+
+</template></CodePanel>
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+  "name": "API docs",
+  "owned_by_id": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "access": 0,
+  "current_user_access": null,
+  "has_pages": true,
+  "is_default": false,
+  "is_global": true,
+  "logo_props": {},
+  "sort_order": 25000.0,
+  "workspace": "95d1f03f-16e5-4807-a8c5-ec0c7cf0e4ab",
+  "created_at": "2026-08-18T10:00:00Z",
+  "updated_at": "2026-08-18T10:05:00Z",
+  "created_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f",
+  "updated_by": "d2f1b470-55e8-4e7a-8a61-7fc695bc1a4f"
+}
+```
+
+</ResponsePanel></div></div>

--- a/docs/api-reference/page/add-workspace-page.md
+++ b/docs/api-reference/page/add-workspace-page.md
@@ -230,7 +230,8 @@ const data = await response.json();
 
 - `201 Created`: the child was created and linked in the parent document.
 - `202 Accepted`: the child was created, but Plane is still retrying the parent link. Store the returned page ID and
-  check the parent later.
+  check the parent later. The response already contains the requested `parent_id`; only the parent document embed is
+  pending.
 - `400 Bad Request`: the parent is locked or archived, or `parent_id` conflicts with `collection_id`.
 - `403 Forbidden`: the caller cannot edit the parent.
 - `404 Not Found`: the parent is unavailable in this workspace.

--- a/docs/api-reference/page/add-workspace-page.md
+++ b/docs/api-reference/page/add-workspace-page.md
@@ -14,7 +14,8 @@ keywords: plane, plane api, rest api, api integration, page, create a wiki page
 <div class="api-two-column">
 <div class="api-left">
 
-Create a workspace page
+Create a workspace page. To create a child page, pass `parent_id`; Plane creates the page and inserts a page embed into
+the parent document. The parent must be visible, editable, unlocked, and active.
 
 <div class="params-section">
 
@@ -94,7 +95,13 @@ External source.
 
 <ApiParam name="description_html" type="string" :required="true">
 
-Description html.
+HTML content for the page body. Plane sanitizes the HTML before storing it.
+
+</ApiParam>
+
+<ApiParam name="parent_id" type="string" :required="false">
+
+UUID of the parent workspace page. Do not combine `parent_id` with `collection_id`.
 
 </ApiParam>
 
@@ -105,7 +112,7 @@ Description html.
 
 ### Scopes
 
-`wiki.pages:write`
+`write` or `wiki.pages:write`
 
 </div>
 
@@ -132,6 +139,7 @@ curl -X POST \
   "logo_props": "example-value",
   "external_id": "550e8400-e29b-41d4-a716-446655440000",
   "external_source": "github",
+  "parent_id": "4d2f6f7e-9b4a-4d6a-8f4a-1c3f7c0f4a10",
   "description_html": "<p>Example content</p>"
 }'
 ```
@@ -155,6 +163,7 @@ response = requests.post(
       "logo_props": "example-value",
       "external_id": "550e8400-e29b-41d4-a716-446655440000",
       "external_source": "github",
+      "parent_id": "4d2f6f7e-9b4a-4d6a-8f4a-1c3f7c0f4a10",
       "description_html": "<p>Example content</p>"
     }
 )
@@ -181,6 +190,7 @@ const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspac
     logo_props: "example-value",
     external_id: "550e8400-e29b-41d4-a716-446655440000",
     external_source: "github",
+    parent_id: "4d2f6f7e-9b4a-4d6a-8f4a-1c3f7c0f4a10",
     description_html: "<p>Example content</p>",
   }),
 });
@@ -215,3 +225,14 @@ const data = await response.json();
 </div>
 
 </div>
+
+## Child-page responses
+
+- `201 Created`: the child was created and linked in the parent document.
+- `202 Accepted`: the child was created, but Plane is still retrying the parent link. Store the returned page ID and
+  check the parent later.
+- `400 Bad Request`: the parent is locked or archived, or `parent_id` conflicts with `collection_id`.
+- `403 Forbidden`: the caller cannot edit the parent.
+- `404 Not Found`: the parent is unavailable in this workspace.
+- `502 Bad Gateway`: the parent link was rejected and the new child was removed.
+- `503 Service Unavailable`: the collaborative document service is not configured.

--- a/docs/api-reference/page/add-workspace-page.md
+++ b/docs/api-reference/page/add-workspace-page.md
@@ -174,10 +174,11 @@ print(response.json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/", {
   method: "POST",
   headers: {
-    "X-API-Key": "your-api-key",
+    "X-API-Key": process.env.PLANE_API_KEY,
     "Content-Type": "application/json",
   },
   body: JSON.stringify({

--- a/docs/api-reference/page/archive-project-page.md
+++ b/docs/api-reference/page/archive-project-page.md
@@ -1,0 +1,51 @@
+---
+title: Archive a project page
+description: Archive a project page via the Plane API before deleting it.
+keywords: plane, plane api, project page, archive page
+---
+
+# Archive a project page
+
+<div class="api-endpoint-badge"><span class="method post">POST</span><span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/archive/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Archive a project page and its subpages. A page must be archived before it can be deleted.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="project_id" type="string" :required="true">The project UUID.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+
+### Scopes
+
+`write` or `projects.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Archive a project page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/archive/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.post("https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/archive/", headers={"X-API-Key": "your-api-key"})
+print(response.status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/archive/",
+  { method: "POST", headers: { "X-API-Key": "your-api-key" } }
+);
+```
+
+</template></CodePanel><ResponsePanel status="204">No response body.</ResponsePanel>
+
+</div></div>

--- a/docs/api-reference/page/archive-project-page.md
+++ b/docs/api-reference/page/archive-project-page.md
@@ -72,9 +72,10 @@ print(response.status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch(
   "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/archive/",
-  { method: "POST", headers: { "X-API-Key": "your-api-key" } }
+  { method: "POST", headers: { "X-API-Key": process.env.PLANE_API_KEY } }
 );
 ```
 

--- a/docs/api-reference/page/archive-project-page.md
+++ b/docs/api-reference/page/archive-project-page.md
@@ -6,30 +6,61 @@ keywords: plane, plane api, project page, archive page
 
 # Archive a project page
 
-<div class="api-endpoint-badge"><span class="method post">POST</span><span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/archive/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method post">POST</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/archive/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Archive a project page and its subpages. A page must be archived before it can be deleted.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="project_id" type="string" :required="true">The project UUID.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="project_id" type="string" :required="true">
+
+The project UUID.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The page UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `write` or `projects.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Archive a project page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Archive a project page" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/archive/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -37,7 +68,8 @@ response = requests.post("https://api.plane.so/api/v1/workspaces/my-workspace/pr
 print(response.status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch(
@@ -46,6 +78,15 @@ const response = await fetch(
 );
 ```
 
-</template></CodePanel><ResponsePanel status="204">No response body.</ResponsePanel>
+</template>
+</CodePanel>
 
-</div></div>
+<ResponsePanel status="204">
+
+No response body.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/page/archive-workspace-page.md
+++ b/docs/api-reference/page/archive-workspace-page.md
@@ -1,0 +1,51 @@
+---
+title: Archive a workspace page
+description: Archive a workspace page via the Plane API before deleting it.
+keywords: plane, plane api, workspace page, archive wiki page
+---
+
+# Archive a workspace page
+
+<div class="api-endpoint-badge"><span class="method post">POST</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/archive/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Archive a workspace page and its subpages. A page must be archived before it can be deleted.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+
+### Scopes
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Archive a workspace page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.post("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/", headers={"X-API-Key": "your-api-key"})
+print(response.status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/", {
+  method: "POST",
+  headers: { "X-API-Key": "your-api-key" },
+});
+```
+
+</template></CodePanel>
+<ResponsePanel status="204">No response body.</ResponsePanel>
+
+</div></div>

--- a/docs/api-reference/page/archive-workspace-page.md
+++ b/docs/api-reference/page/archive-workspace-page.md
@@ -6,29 +6,56 @@ keywords: plane, plane api, workspace page, archive wiki page
 
 # Archive a workspace page
 
-<div class="api-endpoint-badge"><span class="method post">POST</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/archive/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method post">POST</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/archive/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Archive a workspace page and its subpages. A page must be archived before it can be deleted.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The page UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Archive a workspace page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Archive a workspace page" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X POST "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -36,7 +63,8 @@ response = requests.post("https://api.plane.so/api/v1/workspaces/my-workspace/pa
 print(response.status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/", {
@@ -45,7 +73,14 @@ const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspac
 });
 ```
 
-</template></CodePanel>
-<ResponsePanel status="204">No response body.</ResponsePanel>
+</template>
+</CodePanel>
+<ResponsePanel status="204">
 
-</div></div>
+No response body.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/page/archive-workspace-page.md
+++ b/docs/api-reference/page/archive-workspace-page.md
@@ -67,9 +67,10 @@ print(response.status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/", {
   method: "POST",
-  headers: { "X-API-Key": "your-api-key" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY },
 });
 ```
 

--- a/docs/api-reference/page/confirm-workspace-page-attachment-upload.md
+++ b/docs/api-reference/page/confirm-workspace-page-attachment-upload.md
@@ -1,0 +1,59 @@
+---
+title: Confirm a workspace page attachment upload
+description: Confirm the upload status of an attachment linked to a workspace page.
+keywords: plane, plane api, workspace page, confirm attachment upload
+---
+
+# Confirm a workspace page attachment upload
+
+<div class="api-endpoint-badge"><span class="method patch">PATCH</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Set an attachment's upload status after uploading it through the generic asset upload flow. This operation queues storage metadata extraction when needed. The page must be editable and cannot be locked or archived.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The workspace page UUID.</ApiParam>
+<ApiParam name="attachment_id" type="string" :required="true">The attachment asset UUID.</ApiParam>
+
+### Body Parameters
+
+<ApiParam name="is_uploaded" type="boolean" :required="false">Whether the attachment was uploaded successfully. Defaults to `true`.</ApiParam>
+
+### Scopes
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Confirm an attachment upload" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X PATCH "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/" -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" -d '{"is_uploaded":true}'
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.patch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/", headers={"X-API-Key": "your-api-key"}, json={"is_uploaded": True})
+print(response.status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/",
+  {
+    method: "PATCH",
+    headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+    body: JSON.stringify({ is_uploaded: true }),
+  }
+);
+```
+
+</template></CodePanel><ResponsePanel status="204">No response body.</ResponsePanel>
+
+</div></div>

--- a/docs/api-reference/page/confirm-workspace-page-attachment-upload.md
+++ b/docs/api-reference/page/confirm-workspace-page-attachment-upload.md
@@ -6,34 +6,76 @@ keywords: plane, plane api, workspace page, confirm attachment upload
 
 # Confirm a workspace page attachment upload
 
-<div class="api-endpoint-badge"><span class="method patch">PATCH</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method patch">PATCH</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Set an attachment's upload status after uploading it through the generic asset upload flow. This operation queues storage metadata extraction when needed. The page must be editable and cannot be locked or archived.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The workspace page UUID.</ApiParam>
-<ApiParam name="attachment_id" type="string" :required="true">The attachment asset UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The workspace page UUID.
+
+</ApiParam>
+<ApiParam name="attachment_id" type="string" :required="true">
+
+The attachment asset UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Body Parameters
 
-<ApiParam name="is_uploaded" type="boolean" :required="false">Whether the attachment was uploaded successfully. Defaults to `true`.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="is_uploaded" type="boolean" :required="false">
+
+Whether the attachment was uploaded successfully. Defaults to `true`.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Confirm an attachment upload" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Confirm an attachment upload" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X PATCH "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/" -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" -d '{"is_uploaded":true}'
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -41,7 +83,8 @@ response = requests.patch("https://api.plane.so/api/v1/workspaces/my-workspace/p
 print(response.status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch(
@@ -54,6 +97,15 @@ const response = await fetch(
 );
 ```
 
-</template></CodePanel><ResponsePanel status="204">No response body.</ResponsePanel>
+</template>
+</CodePanel>
 
-</div></div>
+<ResponsePanel status="204">
+
+No response body.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/page/confirm-workspace-page-attachment-upload.md
+++ b/docs/api-reference/page/confirm-workspace-page-attachment-upload.md
@@ -87,11 +87,12 @@ print(response.status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch(
   "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/",
   {
     method: "PATCH",
-    headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+    headers: { "X-API-Key": process.env.PLANE_API_KEY, "Content-Type": "application/json" },
     body: JSON.stringify({ is_uploaded: true }),
   }
 );

--- a/docs/api-reference/page/delete-project-page.md
+++ b/docs/api-reference/page/delete-project-page.md
@@ -6,30 +6,61 @@ keywords: plane, plane api, project page, delete page
 
 # Delete a project page
 
-<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method delete">DELETE</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Delete a project page. Archive the page first; deleting an active page returns `400`.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="project_id" type="string" :required="true">The project UUID.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="project_id" type="string" :required="true">
+
+The project UUID.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The page UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `write` or `projects.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Delete a project page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Delete a project page" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -37,7 +68,8 @@ response = requests.delete("https://api.plane.so/api/v1/workspaces/my-workspace/
 print(response.status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch(
@@ -46,6 +78,15 @@ const response = await fetch(
 );
 ```
 
-</template></CodePanel><ResponsePanel status="204">No response body.</ResponsePanel>
+</template>
+</CodePanel>
 
-</div></div>
+<ResponsePanel status="204">
+
+No response body.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/page/delete-project-page.md
+++ b/docs/api-reference/page/delete-project-page.md
@@ -72,9 +72,10 @@ print(response.status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch(
   "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/",
-  { method: "DELETE", headers: { "X-API-Key": "your-api-key" } }
+  { method: "DELETE", headers: { "X-API-Key": process.env.PLANE_API_KEY } }
 );
 ```
 

--- a/docs/api-reference/page/delete-project-page.md
+++ b/docs/api-reference/page/delete-project-page.md
@@ -1,0 +1,51 @@
+---
+title: Delete a project page
+description: Delete an archived project page via the Plane API.
+keywords: plane, plane api, project page, delete page
+---
+
+# Delete a project page
+
+<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Delete a project page. Archive the page first; deleting an active page returns `400`.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="project_id" type="string" :required="true">The project UUID.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+
+### Scopes
+
+`write` or `projects.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Delete a project page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.delete("https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/", headers={"X-API-Key": "your-api-key"})
+print(response.status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/",
+  { method: "DELETE", headers: { "X-API-Key": "your-api-key" } }
+);
+```
+
+</template></CodePanel><ResponsePanel status="204">No response body.</ResponsePanel>
+
+</div></div>

--- a/docs/api-reference/page/delete-workspace-page-attachment.md
+++ b/docs/api-reference/page/delete-workspace-page-attachment.md
@@ -1,0 +1,51 @@
+---
+title: Delete a workspace page attachment
+description: Delete an attachment linked to a workspace page via the Plane API.
+keywords: plane, plane api, workspace page, delete attachment
+---
+
+# Delete a workspace page attachment
+
+<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Soft-delete an attachment from an editable workspace page. Later metadata and download requests return `404`. Locked or archived pages cannot be changed.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The workspace page UUID.</ApiParam>
+<ApiParam name="attachment_id" type="string" :required="true">The attachment asset UUID.</ApiParam>
+
+### Scopes
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Delete an attachment" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.delete("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/", headers={"X-API-Key": "your-api-key"})
+print(response.status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/",
+  { method: "DELETE", headers: { "X-API-Key": "your-api-key" } }
+);
+```
+
+</template></CodePanel><ResponsePanel status="204">No response body.</ResponsePanel>
+
+</div></div>

--- a/docs/api-reference/page/delete-workspace-page-attachment.md
+++ b/docs/api-reference/page/delete-workspace-page-attachment.md
@@ -72,9 +72,10 @@ print(response.status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch(
   "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/",
-  { method: "DELETE", headers: { "X-API-Key": "your-api-key" } }
+  { method: "DELETE", headers: { "X-API-Key": process.env.PLANE_API_KEY } }
 );
 ```
 

--- a/docs/api-reference/page/delete-workspace-page-attachment.md
+++ b/docs/api-reference/page/delete-workspace-page-attachment.md
@@ -6,30 +6,61 @@ keywords: plane, plane api, workspace page, delete attachment
 
 # Delete a workspace page attachment
 
-<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method delete">DELETE</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Soft-delete an attachment from an editable workspace page. Later metadata and download requests return `404`. Locked or archived pages cannot be changed.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The workspace page UUID.</ApiParam>
-<ApiParam name="attachment_id" type="string" :required="true">The attachment asset UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The workspace page UUID.
+
+</ApiParam>
+<ApiParam name="attachment_id" type="string" :required="true">
+
+The attachment asset UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Delete an attachment" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Delete an attachment" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -37,7 +68,8 @@ response = requests.delete("https://api.plane.so/api/v1/workspaces/my-workspace/
 print(response.status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch(
@@ -46,6 +78,15 @@ const response = await fetch(
 );
 ```
 
-</template></CodePanel><ResponsePanel status="204">No response body.</ResponsePanel>
+</template>
+</CodePanel>
 
-</div></div>
+<ResponsePanel status="204">
+
+No response body.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/page/delete-workspace-page.md
+++ b/docs/api-reference/page/delete-workspace-page.md
@@ -67,9 +67,10 @@ print(response.status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/", {
   method: "DELETE",
-  headers: { "X-API-Key": "your-api-key" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY },
 });
 ```
 

--- a/docs/api-reference/page/delete-workspace-page.md
+++ b/docs/api-reference/page/delete-workspace-page.md
@@ -1,0 +1,51 @@
+---
+title: Delete a workspace page
+description: Delete an archived workspace page via the Plane API.
+keywords: plane, plane api, workspace page, delete wiki page
+---
+
+# Delete a workspace page
+
+<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Delete a workspace page. Archive the page before calling this operation; deleting an active page returns `400`.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+
+### Scopes
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Delete a workspace page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.delete("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/", headers={"X-API-Key": "your-api-key"})
+print(response.status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/", {
+  method: "DELETE",
+  headers: { "X-API-Key": "your-api-key" },
+});
+```
+
+</template></CodePanel>
+<ResponsePanel status="204">No response body.</ResponsePanel>
+
+</div></div>

--- a/docs/api-reference/page/delete-workspace-page.md
+++ b/docs/api-reference/page/delete-workspace-page.md
@@ -6,29 +6,56 @@ keywords: plane, plane api, workspace page, delete wiki page
 
 # Delete a workspace page
 
-<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method delete">DELETE</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Delete a workspace page. Archive the page before calling this operation; deleting an active page returns `400`.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The page UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Delete a workspace page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Delete a workspace page" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -36,7 +63,8 @@ response = requests.delete("https://api.plane.so/api/v1/workspaces/my-workspace/
 print(response.status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/", {
@@ -45,7 +73,14 @@ const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspac
 });
 ```
 
-</template></CodePanel>
-<ResponsePanel status="204">No response body.</ResponsePanel>
+</template>
+</CodePanel>
+<ResponsePanel status="204">
 
-</div></div>
+No response body.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/page/download-workspace-page-attachment.md
+++ b/docs/api-reference/page/download-workspace-page-attachment.md
@@ -1,0 +1,53 @@
+---
+title: Download a workspace page attachment
+description: Download an uploaded workspace page attachment through a presigned redirect.
+keywords: plane, plane api, workspace page, download attachment
+---
+
+# Download a workspace page attachment
+
+<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/download/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Validate access and receive a `302` redirect to a temporary presigned download URL. An attachment that has not been confirmed as uploaded returns `400`.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The workspace page UUID.</ApiParam>
+<ApiParam name="attachment_id" type="string" :required="true">The attachment asset UUID.</ApiParam>
+
+### Scopes
+
+`read` or `wiki.pages:read`
+
+</div><div class="api-right">
+<CodePanel title="Download an attachment" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -L "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/download/" -H "X-API-Key: $PLANE_API_KEY" --output diagram.png
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.get("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/download/", headers={"X-API-Key": "your-api-key"})
+open("diagram.png", "wb").write(response.content)
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/download/",
+  { headers: { "X-API-Key": "your-api-key" }, redirect: "follow" }
+);
+const file = await response.blob();
+```
+
+</template></CodePanel>
+<ResponsePanel status="302">The `Location` header contains the temporary presigned download URL.</ResponsePanel>
+
+</div></div>

--- a/docs/api-reference/page/download-workspace-page-attachment.md
+++ b/docs/api-reference/page/download-workspace-page-attachment.md
@@ -6,30 +6,61 @@ keywords: plane, plane api, workspace page, download attachment
 
 # Download a workspace page attachment
 
-<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/download/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/download/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Validate access and receive a `302` redirect to a temporary presigned download URL. An attachment that has not been confirmed as uploaded returns `400`.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The workspace page UUID.</ApiParam>
-<ApiParam name="attachment_id" type="string" :required="true">The attachment asset UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The workspace page UUID.
+
+</ApiParam>
+<ApiParam name="attachment_id" type="string" :required="true">
+
+The attachment asset UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `read` or `wiki.pages:read`
 
-</div><div class="api-right">
-<CodePanel title="Download an attachment" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Download an attachment" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -L "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/download/" -H "X-API-Key: $PLANE_API_KEY" --output diagram.png
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -37,7 +68,8 @@ response = requests.get("https://api.plane.so/api/v1/workspaces/my-workspace/pag
 open("diagram.png", "wb").write(response.content)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch(
@@ -47,7 +79,14 @@ const response = await fetch(
 const file = await response.blob();
 ```
 
-</template></CodePanel>
-<ResponsePanel status="302">The `Location` header contains the temporary presigned download URL.</ResponsePanel>
+</template>
+</CodePanel>
+<ResponsePanel status="302">
 
-</div></div>
+The `Location` header contains the temporary presigned download URL.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/page/download-workspace-page-attachment.md
+++ b/docs/api-reference/page/download-workspace-page-attachment.md
@@ -56,27 +56,58 @@ The attachment asset UUID.
 <template #curl>
 
 ```bash
-curl -L "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/download/" -H "X-API-Key: $PLANE_API_KEY" --output diagram.png
+download_url="$(
+  curl --fail --silent --show-error --dump-header - --output /dev/null \
+    "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/download/" \
+    -H "X-API-Key: $PLANE_API_KEY" \
+    | sed -n 's/^Location: \(https:\/\/.*\)\r$/\1/p'
+)"
+test -n "$download_url"
+curl --fail --location "$download_url" --output diagram.png
 ```
 
 </template>
 <template #python>
 
 ```python
+from urllib.parse import urlparse
+
 import requests
-response = requests.get("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/download/", headers={"X-API-Key": "your-api-key"})
-open("diagram.png", "wb").write(response.content)
+
+response = requests.get(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/download/",
+    headers={"X-API-Key": "your-api-key"},
+    allow_redirects=False,
+)
+response.raise_for_status()
+download_url = response.headers["Location"]
+if urlparse(download_url).scheme != "https":
+    raise ValueError("Expected an HTTPS download URL")
+
+download = requests.get(download_url)
+download.raise_for_status()
+open("diagram.png", "wb").write(download.content)
 ```
 
 </template>
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
+import { writeFile } from "node:fs/promises";
+
 const response = await fetch(
   "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/download/",
-  { headers: { "X-API-Key": "your-api-key" }, redirect: "follow" }
+  { headers: { "X-API-Key": process.env.PLANE_API_KEY }, redirect: "manual" }
 );
-const file = await response.blob();
+if (response.status !== 302) throw new Error(`Expected a redirect, received ${response.status}`);
+
+const downloadUrl = new URL(response.headers.get("location"));
+if (downloadUrl.protocol !== "https:") throw new Error("Expected an HTTPS download URL");
+
+const download = await fetch(downloadUrl);
+if (!download.ok) throw new Error(`Download failed with ${download.status}`);
+await writeFile("diagram.png", Buffer.from(await download.arrayBuffer()));
 ```
 
 </template>

--- a/docs/api-reference/page/download-workspace-page-attachment.md
+++ b/docs/api-reference/page/download-workspace-page-attachment.md
@@ -84,9 +84,11 @@ download_url = response.headers["Location"]
 if urlparse(download_url).scheme != "https":
     raise ValueError("Expected an HTTPS download URL")
 
-download = requests.get(download_url)
-download.raise_for_status()
-open("diagram.png", "wb").write(download.content)
+with requests.get(download_url, stream=True) as download:
+    download.raise_for_status()
+    with open("diagram.png", "wb") as output:
+        for chunk in download.iter_content(chunk_size=8192):
+            output.write(chunk)
 ```
 
 </template>

--- a/docs/api-reference/page/get-workspace-page-attachment.md
+++ b/docs/api-reference/page/get-workspace-page-attachment.md
@@ -1,0 +1,69 @@
+---
+title: Retrieve workspace page attachment metadata
+description: Retrieve metadata for an attachment linked to a workspace page.
+keywords: plane, plane api, workspace page, attachment metadata
+---
+
+# Retrieve workspace page attachment metadata
+
+<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Retrieve metadata and links for an existing workspace page attachment. The caller must be able to view the page.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The workspace page UUID.</ApiParam>
+<ApiParam name="attachment_id" type="string" :required="true">The attachment asset UUID.</ApiParam>
+
+### Scopes
+
+`read` or `wiki.pages:read`
+
+</div><div class="api-right">
+<CodePanel title="Retrieve attachment metadata" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X GET "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.get("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/", headers={"X-API-Key": "your-api-key"})
+print(response.json())
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/",
+  { headers: { "X-API-Key": "your-api-key" } }
+);
+const data = await response.json();
+```
+
+</template></CodePanel>
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "attachment-uuid",
+  "page_id": "page-uuid",
+  "name": "diagram.png",
+  "type": "image/png",
+  "size": 24576,
+  "is_uploaded": true,
+  "asset_url": "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/",
+  "_links": {
+    "download": "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/download/"
+  }
+}
+```
+
+</ResponsePanel>
+</div></div>

--- a/docs/api-reference/page/get-workspace-page-attachment.md
+++ b/docs/api-reference/page/get-workspace-page-attachment.md
@@ -72,9 +72,10 @@ print(response.json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch(
   "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/",
-  { headers: { "X-API-Key": "your-api-key" } }
+  { headers: { "X-API-Key": process.env.PLANE_API_KEY } }
 );
 const data = await response.json();
 ```

--- a/docs/api-reference/page/get-workspace-page-attachment.md
+++ b/docs/api-reference/page/get-workspace-page-attachment.md
@@ -6,30 +6,61 @@ keywords: plane, plane api, workspace page, attachment metadata
 
 # Retrieve workspace page attachment metadata
 
-<div class="api-endpoint-badge"><span class="method get">GET</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method get">GET</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/attachments/{attachment_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Retrieve metadata and links for an existing workspace page attachment. The caller must be able to view the page.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The workspace page UUID.</ApiParam>
-<ApiParam name="attachment_id" type="string" :required="true">The attachment asset UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The workspace page UUID.
+
+</ApiParam>
+<ApiParam name="attachment_id" type="string" :required="true">
+
+The attachment asset UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `read` or `wiki.pages:read`
 
-</div><div class="api-right">
-<CodePanel title="Retrieve attachment metadata" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Retrieve attachment metadata" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X GET "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/attachments/attachment-uuid/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -37,7 +68,8 @@ response = requests.get("https://api.plane.so/api/v1/workspaces/my-workspace/pag
 print(response.json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch(
@@ -47,7 +79,8 @@ const response = await fetch(
 const data = await response.json();
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="200">
 
 ```json
@@ -66,4 +99,6 @@ const data = await response.json();
 ```
 
 </ResponsePanel>
-</div></div>
+</div>
+
+</div>

--- a/docs/api-reference/page/overview.md
+++ b/docs/api-reference/page/overview.md
@@ -6,7 +6,7 @@ keywords: plane, plane api, rest api, api integration, pages, documentation, not
 
 # Overview
 
-Pages allow you to create and manage documentation at both workspace and project levels. Workspace pages are accessible across all projects, while project pages are specific to individual projects.
+Pages allow you to create and manage documentation at both workspace and project levels. Workspace pages are accessible across all projects, while project pages are specific to individual projects. Page body mutations are applied to Plane's collaborative document so API updates remain consistent with active editor sessions.
 
 **Documentation**: [Wiki](https://docs.plane.so/core-concepts/pages/wiki), [Pages](https://docs.plane.so/core-concepts/pages/overview)
 
@@ -44,6 +44,26 @@ Pages allow you to create and manage documentation at both workspace and project
 - `updated_by` _uuid_
 
   ID of the user who last updated the page
+
+- `parent_id` _uuid or null_
+
+  ID of the parent page for a child page
+
+- `collection_id` _uuid or null_
+
+  ID of the collection containing a workspace page
+
+- `page_collection_id` _uuid or null_
+
+  ID of the page's placement record within its collection
+
+- `archived_at` _timestamp or null_
+
+  Time the page was archived
+
+- `is_locked` _boolean_
+
+  Whether content mutations are blocked
 
 </div>
 <div class="api-right">

--- a/docs/api-reference/page/overview.md
+++ b/docs/api-reference/page/overview.md
@@ -78,7 +78,12 @@ Pages allow you to create and manage documentation at both workspace and project
   "name": "Getting Started",
   "description_html": "<h1>Welcome</h1><p>This is a getting started guide.</p>",
   "created_by": "16c61a3a-512a-48ac-b0be-b6b46fe6f430",
-  "updated_by": "16c61a3a-512a-48ac-b0be-b6b46fe6f430"
+  "updated_by": "16c61a3a-512a-48ac-b0be-b6b46fe6f430",
+  "parent_id": null,
+  "collection_id": "0a8a3e6a-3c32-49c7-bbb5-b7a8e32c2f10",
+  "page_collection_id": "1d9b4f7b-56e8-4c63-9ff4-e24b508c162d",
+  "archived_at": null,
+  "is_locked": false
 }
 ```
 

--- a/docs/api-reference/page/page-content-html.md
+++ b/docs/api-reference/page/page-content-html.md
@@ -1,0 +1,177 @@
+---
+title: Page content HTML
+description: Format page body HTML, use Plane editor components, and attach files through the Workspace Page API.
+keywords: plane, plane api, wiki page, description html, page editor, page attachments
+---
+
+# Page content HTML
+
+Send page body content in `description_html` when you create or update a page. Plane sanitizes the HTML, converts it
+to the editor document format, and replaces the complete page body during an update.
+
+> Unsupported tags, attributes, and unsafe URLs can be removed. Fetch the page after a write if your integration
+> needs to inspect the final stored HTML. The maximum HTML payload is 10 MB.
+
+## Standard HTML
+
+The following shapes are suitable for API-created page content:
+
+| Content         | HTML shape                                                        |
+| --------------- | ----------------------------------------------------------------- |
+| Paragraph       | `<p>Text</p>`                                                     |
+| Headings        | `<h1>Title</h1>` through `<h6>Title</h6>`                         |
+| Bold            | `<strong>Bold</strong>`                                           |
+| Italic          | `<em>Italic</em>`                                                 |
+| Underline       | `<u>Underline</u>`                                                |
+| Strikethrough   | `<s>Strike</s>`                                                   |
+| Inline code     | `<code>const value = 1</code>`                                    |
+| Link            | `<a href="https://plane.so">Plane</a>`                            |
+| Blockquote      | `<blockquote><p>Quote</p></blockquote>`                           |
+| Code block      | `<pre><code>const value = 1;</code></pre>`                        |
+| Bullet list     | `<ul><li>Item</li></ul>`                                          |
+| Ordered list    | `<ol start="3"><li>Item</li></ol>`                                |
+| Task list       | `<ul data-type="taskList"><li data-checked="true">Done</li></ul>` |
+| Horizontal rule | `<hr />`                                                          |
+| Table           | `<table><tbody><tr><td>Cell</td></tr></tbody></table>`            |
+| Image           | `<img src="https://example.com/image.png" alt="Image" />`         |
+
+URL attributes support safe protocols such as `http`, `https`, `mailto`, and `tel`.
+
+```html
+<h1>Project brief</h1>
+<p>This page was updated through the API.</p>
+<ul data-type="taskList">
+  <li data-checked="true">Write the brief</li>
+  <li data-checked="false">Review with the team</li>
+</ul>
+<table>
+  <tbody>
+    <tr>
+      <th>Owner</th>
+      <th>Status</th>
+    </tr>
+    <tr>
+      <td>Design</td>
+      <td>In progress</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+## Plane editor components
+
+Entity-backed components must reference existing Plane entities. Use UUIDs, not human-readable work item keys, and do
+not include private user data in page content.
+
+### User mention
+
+```html
+<mention-component id="api-user-mention" entity_identifier="USER_UUID" entity_name="user_mention"> </mention-component>
+```
+
+### Work item embed
+
+```html
+<issue-embed-component
+  id="api-work-item-embed"
+  entity_identifier="WORK_ITEM_UUID"
+  project_identifier="PROJECT_UUID"
+  workspace_identifier="WORKSPACE_SLUG"
+  entity_name="issue"
+>
+</issue-embed-component>
+```
+
+### Page embed
+
+```html
+<page-embed-component
+  id="api-page-embed"
+  entity_identifier="PAGE_UUID"
+  workspace_identifier="WORKSPACE_SLUG"
+  entity_name="sub_page"
+>
+</page-embed-component>
+```
+
+### Image component
+
+```html
+<image-component
+  id="api-image"
+  src="https://example.com/image.png"
+  width="320"
+  height="160"
+  alignment="left"
+  status="uploaded"
+>
+</image-component>
+```
+
+### Callout
+
+```html
+<div data-block-type="callout-component" data-background="#eff6ff" data-logo-in-use="emoji" data-emoji-unicode="128161">
+  <p>This is a callout created through the API.</p>
+</div>
+```
+
+### External embed
+
+```html
+<external-embed-component
+  id="api-external-embed"
+  src="https://plane.so"
+  data-entity-name="Plane"
+  data-entity-type="link"
+  data-is-rich-card="false"
+  data-has-tried-embedding="true"
+  data-has-embed-failed="false"
+>
+</external-embed-component>
+```
+
+### Math and dates
+
+```html
+<p>Inline formula: <inline-math-component id="inline-math" latex="E=mc^2"></inline-math-component></p>
+<block-math-component id="block-math" latex="\\int_0^1 x^2 dx"></block-math-component>
+<p>Target date: <inline-date-component id="target-date" date="2026-08-18"></inline-date-component></p>
+```
+
+## Attach a file
+
+Page attachments use the workspace asset upload flow; there is no multipart page-attachment endpoint.
+
+1. Create upload credentials with
+   [`POST /workspaces/{workspace_slug}/assets/`](/api-reference/assets/create-workspace-asset-upload):
+
+   ```json
+   {
+     "name": "requirements.pdf",
+     "type": "application/pdf",
+     "size": 12345,
+     "entity_type": "PAGE_DESCRIPTION",
+     "entity_identifier": "PAGE_UUID"
+   }
+   ```
+
+2. Upload the file bytes to `upload_data.url` using the returned form fields.
+3. Confirm the upload with the
+   [page attachment endpoint](/api-reference/page/confirm-workspace-page-attachment-upload).
+4. Include the attachment in the complete page body sent through `description_html`:
+
+   ```html
+   <attachment-component
+     id="ASSET_ID_FROM_PLANE"
+     src="ASSET_ID_FROM_PLANE"
+     data-name="requirements.pdf"
+     data-file-size="12345"
+     data-file-type="application/pdf"
+     status="uploaded"
+   >
+   </attachment-component>
+   ```
+
+Use the asset ID returned by Plane. Attachment metadata and downloads remain subject to page visibility; confirming or
+deleting an attachment requires edit access to an unlocked, active page.

--- a/docs/api-reference/page/page-content-html.md
+++ b/docs/api-reference/page/page-content-html.md
@@ -135,7 +135,7 @@ not include private user data in page content.
 
 ```html
 <p>Inline formula: <inline-math-component id="inline-math" latex="E=mc^2"></inline-math-component></p>
-<block-math-component id="block-math" latex="\\int_0^1 x^2 dx"></block-math-component>
+<block-math-component id="block-math" latex="\int_0^1 x^2 dx"></block-math-component>
 <p>Target date: <inline-date-component id="target-date" date="2026-08-18"></inline-date-component></p>
 ```
 

--- a/docs/api-reference/page/restore-project-page.md
+++ b/docs/api-reference/page/restore-project-page.md
@@ -6,30 +6,61 @@ keywords: plane, plane api, project page, restore page, unarchive
 
 # Restore a project page
 
-<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/archive/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method delete">DELETE</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/archive/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Restore an archived project page. Restore an archived parent before restoring its child; otherwise the API returns `400`.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="project_id" type="string" :required="true">The project UUID.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="project_id" type="string" :required="true">
+
+The project UUID.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The page UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `write` or `projects.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Restore a project page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Restore a project page" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/archive/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -37,7 +68,8 @@ response = requests.delete("https://api.plane.so/api/v1/workspaces/my-workspace/
 print(response.status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch(
@@ -46,6 +78,15 @@ const response = await fetch(
 );
 ```
 
-</template></CodePanel><ResponsePanel status="204">No response body.</ResponsePanel>
+</template>
+</CodePanel>
 
-</div></div>
+<ResponsePanel status="204">
+
+No response body.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/page/restore-project-page.md
+++ b/docs/api-reference/page/restore-project-page.md
@@ -1,0 +1,51 @@
+---
+title: Restore a project page
+description: Restore an archived project page via the Plane API.
+keywords: plane, plane api, project page, restore page, unarchive
+---
+
+# Restore a project page
+
+<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/archive/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Restore an archived project page. Restore an archived parent before restoring its child; otherwise the API returns `400`.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="project_id" type="string" :required="true">The project UUID.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+
+### Scopes
+
+`write` or `projects.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Restore a project page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/archive/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.delete("https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/archive/", headers={"X-API-Key": "your-api-key"})
+print(response.status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/archive/",
+  { method: "DELETE", headers: { "X-API-Key": "your-api-key" } }
+);
+```
+
+</template></CodePanel><ResponsePanel status="204">No response body.</ResponsePanel>
+
+</div></div>

--- a/docs/api-reference/page/restore-project-page.md
+++ b/docs/api-reference/page/restore-project-page.md
@@ -72,9 +72,10 @@ print(response.status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch(
   "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/archive/",
-  { method: "DELETE", headers: { "X-API-Key": "your-api-key" } }
+  { method: "DELETE", headers: { "X-API-Key": process.env.PLANE_API_KEY } }
 );
 ```
 

--- a/docs/api-reference/page/restore-workspace-page.md
+++ b/docs/api-reference/page/restore-workspace-page.md
@@ -1,0 +1,51 @@
+---
+title: Restore a workspace page
+description: Restore an archived workspace page via the Plane API.
+keywords: plane, plane api, workspace page, restore wiki page, unarchive
+---
+
+# Restore a workspace page
+
+<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/archive/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Restore an archived workspace page. If its parent is archived, restore the parent before restoring the child; otherwise the API returns `400`.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+
+### Scopes
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Restore a workspace page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/" -H "X-API-Key: $PLANE_API_KEY"
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.delete("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/", headers={"X-API-Key": "your-api-key"})
+print(response.status_code)
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/", {
+  method: "DELETE",
+  headers: { "X-API-Key": "your-api-key" },
+});
+```
+
+</template></CodePanel>
+<ResponsePanel status="204">No response body.</ResponsePanel>
+
+</div></div>

--- a/docs/api-reference/page/restore-workspace-page.md
+++ b/docs/api-reference/page/restore-workspace-page.md
@@ -67,9 +67,10 @@ print(response.status_code)
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/", {
   method: "DELETE",
-  headers: { "X-API-Key": "your-api-key" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY },
 });
 ```
 

--- a/docs/api-reference/page/restore-workspace-page.md
+++ b/docs/api-reference/page/restore-workspace-page.md
@@ -6,29 +6,56 @@ keywords: plane, plane api, workspace page, restore wiki page, unarchive
 
 # Restore a workspace page
 
-<div class="api-endpoint-badge"><span class="method delete">DELETE</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/archive/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method delete">DELETE</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/archive/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Restore an archived workspace page. If its parent is archived, restore the parent before restoring the child; otherwise the API returns `400`.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The page UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Restore a workspace page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Restore a workspace page" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X DELETE "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/" -H "X-API-Key: $PLANE_API_KEY"
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -36,7 +63,8 @@ response = requests.delete("https://api.plane.so/api/v1/workspaces/my-workspace/
 print(response.status_code)
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/archive/", {
@@ -45,7 +73,14 @@ const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspac
 });
 ```
 
-</template></CodePanel>
-<ResponsePanel status="204">No response body.</ResponsePanel>
+</template>
+</CodePanel>
+<ResponsePanel status="204">
 
-</div></div>
+No response body.
+
+</ResponsePanel>
+
+</div>
+
+</div>

--- a/docs/api-reference/page/update-project-page.md
+++ b/docs/api-reference/page/update-project-page.md
@@ -1,0 +1,75 @@
+---
+title: Update a project page
+description: Update the title or content of a project page via the Plane API.
+keywords: plane, plane api, project page, update page
+---
+
+# Update a project page
+
+<div class="api-endpoint-badge"><span class="method put">PUT</span><span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Send `name`, `description_html`, or both. `description_html` replaces the current content. Locked or archived pages return `400`; document-service failures return `502`, and an unconfigured service returns `503`.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="project_id" type="string" :required="true">The project UUID.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+
+### Body Parameters
+
+<ApiParam name="name" type="string" :required="false">The new page title.</ApiParam>
+<ApiParam name="description_html" type="string" :required="false">HTML that replaces the current page content.</ApiParam>
+
+At least one body parameter is required.
+
+### Scopes
+
+`write` or `projects.pages:write`
+
+</div><div class="api-right">
+<CodePanel title="Update a project page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+
+```bash
+curl -X PUT "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/" \
+  -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" \
+  -d '{"name":"Release notes","description_html":"<p>Current release notes</p>"}'
+```
+
+</template><template #python>
+
+```python
+import requests
+response = requests.put("https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/", headers={"X-API-Key": "your-api-key"}, json={"name": "Release notes", "description_html": "<p>Current release notes</p>"})
+print(response.json())
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch(
+  "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/",
+  {
+    method: "PUT",
+    headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Release notes", description_html: "<p>Current release notes</p>" }),
+  }
+);
+const data = await response.json();
+```
+
+</template></CodePanel>
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "Release notes",
+  "description_html": "<p>Current release notes</p>"
+}
+```
+
+</ResponsePanel>
+</div></div>

--- a/docs/api-reference/page/update-project-page.md
+++ b/docs/api-reference/page/update-project-page.md
@@ -6,31 +6,79 @@ keywords: plane, plane api, project page, update page
 
 # Update a project page
 
-<div class="api-endpoint-badge"><span class="method put">PUT</span><span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method put">PUT</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/projects/{project_id}/pages/{page_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
-Send `name`, `description_html`, or both. `description_html` replaces the current content. Locked or archived pages return `400`; document-service failures return `502`, and an unconfigured service returns `503`.
+Send `name`, `description_html`, or both. `description_html` replaces the current content, and Plane sanitizes it before
+storing it. See [Page content HTML](/api-reference/page/page-content-html) for supported HTML and Plane editor
+components. Locked or archived pages return `400`; document-service failures return `502`, and an unconfigured service
+returns `503`.
+
+<div class="params-section">
 
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="project_id" type="string" :required="true">The project UUID.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="project_id" type="string" :required="true">
+
+The project UUID.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The page UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Body Parameters
 
-<ApiParam name="name" type="string" :required="false">The new page title.</ApiParam>
-<ApiParam name="description_html" type="string" :required="false">HTML that replaces the current page content.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="name" type="string" :required="false">
+
+The new page title.
+
+</ApiParam>
+<ApiParam name="description_html" type="string" :required="false">
+
+HTML that Plane sanitizes and uses to replace the current page content.
+
+</ApiParam>
 
 At least one body parameter is required.
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `write` or `projects.pages:write`
 
-</div><div class="api-right">
-<CodePanel title="Update a project page" :languages="['cURL', 'Python', 'JavaScript']"><template #curl>
+</div>
+
+</div>
+
+<div class="api-right">
+<CodePanel title="Update a project page" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
 
 ```bash
 curl -X PUT "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/" \
@@ -38,7 +86,8 @@ curl -X PUT "https://api.plane.so/api/v1/workspaces/my-workspace/projects/projec
   -d '{"name":"Release notes","description_html":"<p>Current release notes</p>"}'
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -46,7 +95,8 @@ response = requests.put("https://api.plane.so/api/v1/workspaces/my-workspace/pro
 print(response.json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch(
@@ -60,7 +110,8 @@ const response = await fetch(
 const data = await response.json();
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 <ResponsePanel status="200">
 
 ```json
@@ -72,4 +123,6 @@ const data = await response.json();
 ```
 
 </ResponsePanel>
-</div></div>
+</div>
+
+</div>

--- a/docs/api-reference/page/update-project-page.md
+++ b/docs/api-reference/page/update-project-page.md
@@ -99,11 +99,12 @@ print(response.json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch(
   "https://api.plane.so/api/v1/workspaces/my-workspace/projects/project-uuid/pages/page-uuid/",
   {
     method: "PUT",
-    headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+    headers: { "X-API-Key": process.env.PLANE_API_KEY, "Content-Type": "application/json" },
     body: JSON.stringify({ name: "Release notes", description_html: "<p>Current release notes</p>" }),
   }
 );

--- a/docs/api-reference/page/update-workspace-page.md
+++ b/docs/api-reference/page/update-workspace-page.md
@@ -99,9 +99,10 @@ print(response.json())
 <template #javascript>
 
 ```javascript
+// Run this example server-side. Browser apps must call your backend to keep the API key secret.
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/", {
   method: "PUT",
-  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  headers: { "X-API-Key": process.env.PLANE_API_KEY, "Content-Type": "application/json" },
   body: JSON.stringify({ name: "Release notes", description_html: "<p>Current release notes</p>" }),
 });
 const data = await response.json();

--- a/docs/api-reference/page/update-workspace-page.md
+++ b/docs/api-reference/page/update-workspace-page.md
@@ -1,0 +1,81 @@
+---
+title: Update a workspace page
+description: Update the title or content of a workspace page via the Plane API.
+keywords: plane, plane api, rest api, workspace page, update wiki page
+---
+
+# Update a workspace page
+
+<div class="api-endpoint-badge"><span class="method put">PUT</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/</span></div>
+
+<div class="api-two-column"><div class="api-left">
+
+Update a workspace page. Send `name`, `description_html`, or both. `description_html` replaces the page's current content rather than appending to it. Plane applies the mutation through its collaborative document service so API writes remain consistent with active editor sessions. Locked or archived pages cannot be updated. The API returns `502` when the collaborative document service cannot complete the update and `503` when that service is not configured.
+
+See [Page content HTML](/api-reference/page/page-content-html) for supported HTML and Plane editor components.
+
+### Path Parameters
+
+<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+
+### Body Parameters
+
+<ApiParam name="name" type="string" :required="false">The new page title.</ApiParam>
+<ApiParam name="description_html" type="string" :required="false">HTML that replaces the current page content.</ApiParam>
+
+At least one body parameter is required.
+
+### Scopes
+
+`write` or `wiki.pages:write`
+
+</div><div class="api-right">
+
+<CodePanel title="Update a workspace page" :languages="['cURL', 'Python', 'JavaScript']">
+<template #curl>
+
+```bash
+curl -X PUT "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/" \
+  -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" \
+  -d '{"name":"Release notes","description_html":"<p>Current release notes</p>"}'
+```
+
+</template><template #python>
+
+```python
+import requests
+
+response = requests.put(
+    "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/",
+    headers={"X-API-Key": "your-api-key"},
+    json={"name": "Release notes", "description_html": "<p>Current release notes</p>"},
+)
+print(response.json())
+```
+
+</template><template #javascript>
+
+```javascript
+const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/", {
+  method: "PUT",
+  headers: { "X-API-Key": "your-api-key", "Content-Type": "application/json" },
+  body: JSON.stringify({ name: "Release notes", description_html: "<p>Current release notes</p>" }),
+});
+const data = await response.json();
+```
+
+</template></CodePanel>
+
+<ResponsePanel status="200">
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "Release notes",
+  "description_html": "<p>Current release notes</p>"
+}
+```
+
+</ResponsePanel>
+</div></div>

--- a/docs/api-reference/page/update-workspace-page.md
+++ b/docs/api-reference/page/update-workspace-page.md
@@ -6,31 +6,71 @@ keywords: plane, plane api, rest api, workspace page, update wiki page
 
 # Update a workspace page
 
-<div class="api-endpoint-badge"><span class="method put">PUT</span><span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/</span></div>
+<div class="api-endpoint-badge">
+  <span class="method put">PUT</span>
+  <span class="path">/api/v1/workspaces/{workspace_slug}/pages/{page_id}/</span>
+</div>
 
-<div class="api-two-column"><div class="api-left">
+<div class="api-two-column">
+<div class="api-left">
 
 Update a workspace page. Send `name`, `description_html`, or both. `description_html` replaces the page's current content rather than appending to it. Plane applies the mutation through its collaborative document service so API writes remain consistent with active editor sessions. Locked or archived pages cannot be updated. The API returns `502` when the collaborative document service cannot complete the update and `503` when that service is not configured.
 
 See [Page content HTML](/api-reference/page/page-content-html) for supported HTML and Plane editor components.
 
+<div class="params-section">
+
 ### Path Parameters
 
-<ApiParam name="workspace_slug" type="string" :required="true">The workspace's unique slug.</ApiParam>
-<ApiParam name="page_id" type="string" :required="true">The page UUID.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="workspace_slug" type="string" :required="true">
+
+The workspace's unique slug.
+
+</ApiParam>
+<ApiParam name="page_id" type="string" :required="true">
+
+The page UUID.
+
+</ApiParam>
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Body Parameters
 
-<ApiParam name="name" type="string" :required="false">The new page title.</ApiParam>
-<ApiParam name="description_html" type="string" :required="false">HTML that replaces the current page content.</ApiParam>
+<div class="params-list">
+
+<ApiParam name="name" type="string" :required="false">
+
+The new page title.
+
+</ApiParam>
+<ApiParam name="description_html" type="string" :required="false">
+
+HTML that replaces the current page content.
+
+</ApiParam>
 
 At least one body parameter is required.
+
+</div>
+</div>
+
+<div class="params-section">
 
 ### Scopes
 
 `write` or `wiki.pages:write`
 
-</div><div class="api-right">
+</div>
+
+</div>
+
+<div class="api-right">
 
 <CodePanel title="Update a workspace page" :languages="['cURL', 'Python', 'JavaScript']">
 <template #curl>
@@ -41,7 +81,8 @@ curl -X PUT "https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid
   -d '{"name":"Release notes","description_html":"<p>Current release notes</p>"}'
 ```
 
-</template><template #python>
+</template>
+<template #python>
 
 ```python
 import requests
@@ -54,7 +95,8 @@ response = requests.put(
 print(response.json())
 ```
 
-</template><template #javascript>
+</template>
+<template #javascript>
 
 ```javascript
 const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspace/pages/page-uuid/", {
@@ -65,7 +107,8 @@ const response = await fetch("https://api.plane.so/api/v1/workspaces/my-workspac
 const data = await response.json();
 ```
 
-</template></CodePanel>
+</template>
+</CodePanel>
 
 <ResponsePanel status="200">
 
@@ -78,4 +121,6 @@ const data = await response.json();
 ```
 
 </ResponsePanel>
-</div></div>
+</div>
+
+</div>


### PR DESCRIPTION
### Description

Documents the recently added public Page and Collection APIs:

- Adds workspace and project page update, archive, restore, and delete endpoint documentation.
- Documents collaborative workspace page updates, child-page creation behavior, supported `description_html` content, and page attachment upload/download flows.
- Adds complete Collection API documentation for collection metadata, private membership, page listing/search, placement, moving, reordering, and removal.
- Updates the workspace asset upload documentation for `PAGE_DESCRIPTION` assets.
- Adds all new Page and Collection pages to the API reference sidebar.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [x] Documentation update

### Screenshots and Media (if applicable)

Screenshots captured from the local VitePress site at a 1600 × 1000 desktop viewport.

#### Workspace page update endpoint

Shows the collaborative page update reference, request/response examples, and expanded Pages navigation.

![Workspace page update API reference](https://ampcode.com/user-content/artifacts/27b9ee9aca834d6b5e75dbc753f5fdb2f75907bd3b015a7dc2fdb5019dc53ae3-file.png)

#### Add pages to a collection

Shows collection placement parameters, multi-language examples, response schema, and expanded Collections navigation.

![Add pages to a collection API reference](https://ampcode.com/user-content/artifacts/37afd97f5ac760edf321b9371150279be1f8cf87201914a9e65e88efe7646128-file.png)

#### Page content HTML guide

Shows the supported HTML reference and the new Page documentation navigation.

![Page content HTML guide](https://ampcode.com/user-content/artifacts/af63e41d78006ce456129fdc3165f61b30916dd5017f7358d163c41fefd1cdf1-file.png)

### Test Scenarios

- Verified every Page and Collection Markdown file has a matching sidebar entry and that every sidebar route resolves to a source file.
- Ran Prettier checks for the VitePress config and affected API documentation.
- Ran the VitePress TypeScript configuration check.
- Built the complete VitePress site successfully.
- Confirmed no API v2 routes remain in the documentation.

### References

- WIKI-1068
- https://github.com/makeplane/plane-ee/pull/7868
- https://github.com/makeplane/plane-ee/pull/8407
- https://github.com/makeplane/plane-ee/pull/9007


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded API reference coverage for workspace and project page creation, updates, archiving, restoration, deletion, and attachments.
  * Added comprehensive collection documentation, including creation, retrieval, updates, deletion, page management, searching, and member access controls.
  * Documented workspace page attachment upload, confirmation, metadata retrieval, downloading, and deletion workflows.
  * Added guidance for child pages, HTML content, sanitization, editor components, page hierarchy, locking, archiving, and collection metadata.
  * Updated navigation and included cURL, Python, and JavaScript examples with permissions and response details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
